### PR TITLE
helm name syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ is tailored specifically to GKE.
 To install the chart with the release name `neo4j-helm`:
 
 ```bash
-$ helm install my-neo4j stable/neo4j --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword
+$ helm install --name my-neo4j stable/neo4j --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword
 ```
 
 You must explicitly accept the neo4j license agreement for the installation to be successful.


### PR DESCRIPTION
If I do what's in the current README, then I get this error

```
> helm install my-neo4j stable/neo4j --set acceptLicenseAgreement=yes --set neo4jPassword=<password>
Error: This command needs 1 argument: chart name
```

Below is my helm verisons
```
Client: &version.Version{SemVer:"v2.16.6", GitCommit:"dd2e5695da88625b190e6b22e9542550ab503a47", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.16.6", GitCommit:"dd2e5695da88625b190e6b22e9542550ab503a47", GitTreeState:"clean"}
```