### PR TITLE
Fix base64 command arguments

### DIFF
--- a/external-exposure/EXTERNAL-EXPOSURE.md
+++ b/external-exposure/EXTERNAL-EXPOSURE.md
@@ -222,7 +222,7 @@ After all of these steps, you should end up with a cluster properly exposed.   W
 like so, and connect to any of the 3 static IPs.
 
 ```
-export NEO4J_PASSWORD=$(kubectl get secrets graph-neo4j-secrets -o yaml | grep password | sed 's/.*: //' | base64 -D)
+export NEO4J_PASSWORD=$(kubectl get secrets graph-neo4j-secrets -o yaml | grep password | sed 's/.*: //' | base64 -d)
 cypher-shell -a neo4j://34.66.183.174:7687 -u neo4j -p "$NEO4J_PASSWORD"
 ```
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -17,7 +17,7 @@ $ kubectl logs --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={
 
 We can now run a query to find the topology of the cluster.
 
-export NEO4J_PASSWORD=$(kubectl get secrets {{ template "neo4j.secrets.fullname" . }} --namespace {{ .Release.Namespace }} -o yaml | grep password | sed 's/.*: //' | base64 -D)
+export NEO4J_PASSWORD=$(kubectl get secrets {{ template "neo4j.secrets.fullname" . }} --namespace {{ .Release.Namespace }} -o yaml | grep password | sed 's/.*: //' | base64 -d)
 kubectl run -it --rm cypher-shell \
     --image={{ .Values.image }}:{{ .Values.imageTag }} \
     --restart=Never \

--- a/user-guide/USER-GUIDE.md
+++ b/user-guide/USER-GUIDE.md
@@ -151,7 +151,7 @@ exposed externally.  See below for information on proxying and other limitations
 After installing, your cluster will start with a strong password that was randomly generated in the startup process.   This is stored in a kubernetes secret that is attached to your deployment.   Given a deployment named “my-graph”, you can find the password as the “neo4j-password” key under the mygraph-neo4j-secrets configuration item in Kubernetes.   The password is base64 encoded, and can be recovered as plaintext by authorized users with this command:
 
 ```
-export NEO4J_PASSWORD=$(kubectl get secrets {{ template "neo4j.secrets.fullname" . }} -o yaml | grep password | sed 's/.*: //' | base64 -D)
+export NEO4J_PASSWORD=$(kubectl get secrets {{ template "neo4j.secrets.fullname" . }} -o yaml | grep password | sed 's/.*: //' | base64 -d)
 ```
 
 This password applies for the base administrative user named “neo4j”.


### PR DESCRIPTION
As tested by me, `base64 -d` is more common in many distributions compared to `-D`. Also, there are some distributions with only `base64 -d`, not `base64 -D`. Therefore, I recommend to change `-D` here to `-d`.