### PR TITLE
Allow setting SVC type & use ClusterIP default

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 4.0.4-1
+version: 4.0.4-2
 appVersion: 4.0.4
 description: Neo4j is the world's leading graph database
 keywords:

--- a/templates/core-dns.yaml
+++ b/templates/core-dns.yaml
@@ -11,9 +11,27 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/name: {{ template "neo4j.name" . }}
     app.kubernetes.io/component: core
+{{- with .Values.core.service.labels }}
+    {{ toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.core.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
+{{- if (or (eq .Values.core.service.type "ClusterIP") (empty .Values.core.service.type)) }}
+  type: ClusterIP
   clusterIP: None
-  publishNotReadyAddresses: true 
+{{- else if eq .Values.core.service.type "LoadBalancer" }}
+  type: LoadBalancer
+  {{- with .Values.core.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{ toYaml . | nindent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.core.service.type }}
+{{- end }}
+  publishNotReadyAddresses: true
   ports:
     - name: http
       port: 7474

--- a/templates/discovery-lb.yaml
+++ b/templates/discovery-lb.yaml
@@ -1,4 +1,4 @@
-# This creates a discovery LB for each member in the core set, and ties to 
+# This creates a discovery Service for each member in the core set, and ties to
 # the use of the Neo4j discovery type "K8S" with the configured selectors.
 {{- $dot := . }}
 {{- $times := int .Values.core.numberOfServers }}
@@ -16,9 +16,27 @@ metadata:
     helm.sh/chart: "{{ $dot.Chart.Name }}-{{ $dot.Chart.Version }}"
     app.kubernetes.io/name: {{ template "neo4j.name" $dot }}
     app.kubernetes.io/component: core
+{{- with $dot.Values.core.discoveryService.labels }}
+    {{ toYaml . | nindent 4 }}
+{{- end }}
+{{- with $dot.Values.core.discoveryService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
-  publishNotReadyAddresses: true
+{{- if (or (eq $dot.Values.core.discoveryService.type "ClusterIP") (empty $dot.Values.core.discoveryService.type)) }}
+  type: ClusterIP
+  clusterIP: None
+{{- else if eq $dot.Values.core.discoveryService.type "LoadBalancer" }}
   type: LoadBalancer
+  {{- with $dot.Values.core.discoveryService.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{ toYaml . | nindent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ $dot.Values.core.discoveryService.type }}
+{{- end }}
+  publishNotReadyAddresses: true
   ports:
     - name: discovery
       port: 5000
@@ -52,4 +70,4 @@ spec:
 {{- end }}
   selector:
     statefulset.kubernetes.io/pod-name: "{{ template "neo4j.fullname" $dot }}-core-{{ . }}"
-{{- end }}    
+{{- end }}

--- a/templates/readreplicas-dns.yaml
+++ b/templates/readreplicas-dns.yaml
@@ -10,9 +10,27 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app.kubernetes.io/name: {{ template "neo4j.replica.fullname" . }}
-    app.kubernetes.io/component: core
+    app.kubernetes.io/component: replica
+{{- with .Values.readReplica.service.labels }}
+    {{ toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.readReplica.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
+{{- if (or (eq .Values.readReplica.service.type "ClusterIP") (empty .Values.readReplica.service.type)) }}
+  type: ClusterIP
   clusterIP: None
+{{- else if eq .Values.readReplica.service.type "LoadBalancer" }}
+  type: LoadBalancer
+  {{- with .Values.readReplica.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{ toYaml . | nindent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.readReplica.service.type }}
+{{- end }}
   publishNotReadyAddresses: true 
   ports:
     - name: http

--- a/user-guide/USER-GUIDE.md
+++ b/user-guide/USER-GUIDE.md
@@ -67,6 +67,14 @@ their default values.
 | `core.persistentVolume.mountPath`     | Persistent Volume mount root path                                                                                                       | `/data`                                         |
 | `core.persistentVolume.subPath`       | Subdirectory of the volume to mount                                                                                                     | `nil`                                           |
 | `core.persistentVolume.annotations`   | Persistent Volume Claim annotations                                                                                                     | `{}`                                            |
+| `core.service.type` | Service type | `ClusterIP` |
+| `core.service.annotations` | Service annotations | `{}` |
+| `core.service.labels` | Custom Service labels | `{}` |
+| `core.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to LB (if `core.service.type: LoadBalancer`) | `[]` |
+| `core.discoveryService.type` | Service type | `ClusterIP` |
+| `core.discoveryService.annotations` | Service annotations | `{}` |
+| `core.discoveryService.labels` | Custom Service labels | `{}` |
+| `core.discoveryService.loadBalancerSourceRanges` | List of IP CIDRs allowed access to LB (if `core.discoveryService.type: LoadBalancer`) | `[]` |
 | `readReplica.configMap`               | Configmap providing configuration for RR cluster members.  If not specified, defaults that come with the chart will be used.            | `$NAME-neo4j-replica-config`                    |
 | `readReplica.numberOfServers`         | Number of machines in READ_REPLICA mode                                                                                                 | `0`                                             |
 | `readReplica.autoscaling.enabled`  | Enable horizontal pod autoscaler  | `false`  |
@@ -74,6 +82,10 @@ their default values.
 | `readReplica.autoscaling.minReplicas` | Min replicas for autoscaling  | `1`  |
 | `readReplica.autoscaling.maxReplicas`  | Max replicas for autoscaling  | `3` |
 | `readReplica.initContainers`          | Init containers to add to the replica pods. Example use case is a script that installs custom plugins/extensions                        | `{}`                                            |
+| `readReplica.service.type` | Service type | `ClusterIP` |
+| `readReplica.service.annotations` | Service annotations | `{}` |
+| `readReplica.service.labels` | Custom Service labels | `{}` |
+| `readReplica.service.loadBalancerSourceRanges` | List of IP CIDRs allowed accessto LB (if `readReplica.service.type: LoadBalancer`) | `[]` |
 | `resources`                           | Resources required (e.g. CPU, memory)                                                                                                   | `{}`                                            |
 | `clusterDomain`                       | Cluster domain                                                                                                                          | `cluster.local`                                 |
 

--- a/values.yaml
+++ b/values.yaml
@@ -103,9 +103,28 @@ core:
   #       curl -L https://somesite.com/path/to/plugin.jar -O
   #       cp plugin.jar /plugins/
 
+  ## This service is intended for clients running in kubernetes to connect to
+  ## the cluster.
+  ## Default: ClusterIP (headless)
+  service:
+    type: ClusterIP
+    annotations: {}
+    labels: {}
+    loadBalancerSourceRanges: []
+
+  ## This creates a discovery Service for each member in the core set, and ties
+  ## to the use of the Neo4j discovery type "K8S" with the configured selectors.
+  ## Default: ClusterIP (headless)
+  discoveryService:
+    type: ClusterIP
+    annotations: {}
+    labels: {}
+    loadBalancerSourceRanges: []
+
 # Read Replicas
 readReplica:
   # configMap: "my-custom-configmap"
+
   resources: {}
   # limits:
   #   cpu: 100m
@@ -113,6 +132,7 @@ readReplica:
   # requests:
   #   cpu: 100m
   #   memory: 512Mi
+
   autoscaling:
     enabled: false
     targetAverageUtilization: 70
@@ -143,6 +163,15 @@ readReplica:
   #     - |
   #       curl -L https://somesite.com/path/to/plugin.jar -O
   #       cp plugin.jar /plugins/
+
+  ## This service is intended for clients running in kubernetes to connect to
+  ## the cluster replica set.
+  ## Default: ClusterIP (headless)
+  service:
+    type: ClusterIP
+    annotations: {}
+    labels: {}
+    loadBalancerSourceRanges: []
 
 resources: {}
   # limits:
@@ -183,7 +212,7 @@ metrics:
     server: localhost:2003
     interval: 3s
     # This will be set to the app name later.
-    # metrics.prefix=Neo4j_1   
+    # metrics.prefix=Neo4j_1
   prometheus:
     ## Publish metrics for polling as Prometheus endpoint
     enabled: false


### PR DESCRIPTION
Signed-off-by: Philip Dubois <hello@philipdubois.be>

Fixes #14 

This change allows the user to choose which type of Services to use. By default a headless ClusterIP service is used to expose Neo4j *only* within K8s. However for example a LoadBalancer type can also be used to expose Neo4j to the (internal) network outside K8s (using the proper annotations).