### PR TITLE
Remove LoadBalancer type from Service

### DIFF
--- a/templates/discovery-lb.yaml
+++ b/templates/discovery-lb.yaml
@@ -1,4 +1,4 @@
-# This creates a discovery LB for each member in the core set, and ties to 
+# This creates a discovery LB for each member in the core set, and ties to
 # the use of the Neo4j discovery type "K8S" with the configured selectors.
 {{- $dot := . }}
 {{- $times := int .Values.core.numberOfServers }}
@@ -18,7 +18,6 @@ metadata:
     app.kubernetes.io/component: core
 spec:
   publishNotReadyAddresses: true
-  type: LoadBalancer
   ports:
     - name: discovery
       port: 5000
@@ -52,4 +51,4 @@ spec:
 {{- end }}
   selector:
     statefulset.kubernetes.io/pod-name: "{{ template "neo4j.fullname" $dot }}-core-{{ . }}"
-{{- end }}    
+{{- end }}


### PR DESCRIPTION
On GKE, services with the LoadBalancer type will automatically create an external IP address
and network load balancer to direct traffic to the Service. Thus, this is exposing the
neo4j cluster to the internet by default.

This change makes the service a normal Service, which works fine for routing within the Kubernetes cluster.