### PR TITLE
Standalone mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           name: Wait for GKE STANDALONE deployment to succeed and become ready
           command: |
               NAMESPACE=ns-$CIRCLE_BUILD_NUM
-              kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME_STANDALONE-neo4j-core --watch | tee -a $BUILD_ARTIFACTS/wait.txt
+              kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME_STANDALONE-neo4j-core --watch | tee -a $BUILD_ARTIFACTS/wait-standalone.txt
       
       # We're going to test standalone first because it forms faster than cluster.  In the background,
       # cluster is still forming....
@@ -144,13 +144,13 @@ jobs:
           name: Wait for GKE CLUSTERED deployment to succeed and become ready
           command: |
              NAMESPACE=ns-$CIRCLE_BUILD_NUM
-             kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME-cluster-neo4j-core --watch | tee -a $BUILD_ARTIFACTS/wait.txt
+             kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME_CLUSTERED-neo4j-core --watch | tee -a $BUILD_ARTIFACTS/wait-cluster.txt
 
       - run:
           name: Test
           command: |
             NAMESPACE=ns-$CIRCLE_BUILD_NUM
-            helm test $NAME_CLUSTERED --namespace $NAMESPACE --logs | tee -a $BUILD_ARTIFACTS/TEST.txt
+            helm test $NAME_CLUSTERED --namespace $NAMESPACE --logs | tee -a $BUILD_ARTIFACTS/TEST-CLUSTER.txt
 
       - run:
           name: Uninstall / Cleanup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,13 +118,13 @@ jobs:
                  -v 3 | tee -a $BUILD_ARTIFACTS/INSTALL-standalone.txt
                      
 
-      - run:
-          name: Twiddling our Thumbs
-          command: |
-            sleep 10
-            NAMESPACE=ns-$CIRCLE_BUILD_NUM
-            kubectl logs --namespace $NAMESPACE \
-              -l "app.kubernetes.io/name=neo4j,app.kubernetes.io/component=core" | tee -a $BUILD_ARTIFACTS/startlogs.txt
+      #- run:
+      #    name: Twiddling our Thumbs
+      #    command: |
+      #      sleep 60
+      #      NAMESPACE=ns-$CIRCLE_BUILD_NUM
+      #      kubectl logs --namespace $NAMESPACE \
+      #        -l "app.kubernetes.io/name=neo4j,app.kubernetes.io/component=core" | tee -a $BUILD_ARTIFACTS/startlogs.txt
 
       - run:
           name: Wait for GKE STANDALONE deployment to succeed and become ready

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
       CLUSTER: ci-test
       ZONE: us-central1-a
       NODES: 3
-      NAME: testrun
+      NAME_CLUSTERED: testrunc
+      NAME_STANDALONE: testrunsa
       BUILD_ARTIFACTS: build
 
     steps:
@@ -97,33 +98,59 @@ jobs:
              helm package .
              chart_archive=$(ls neo4j*.tgz)
              cp *.tgz $BUILD_ARTIFACTS/
-             echo "Installing $chart_archive"
-             helm install $NAME $chart_archive \
+
+             echo "Installing $chart_archive (CAUSAL CLUSTER TEST SCENARIO)"
+             helm install $NAME_CLUSTERED $chart_archive \
                  --namespace $NAMESPACE \
                  --set acceptLicenseAgreement=yes \
                  --set neo4jPassword=mySecretPassword \
                  --set readReplica.numberOfServers=1 \
-                 -v 3 | tee -a $BUILD_ARTIFACTS/INSTALL.txt
-             
+                 -v 3 | tee -a $BUILD_ARTIFACTS/INSTALL-cluster.txt
+
+             echo "Installing $chart_archive (STANDALONE SCENARIO)"
+             helm install $NAME_STANDALONE $chart_archive \
+                 --namespace $NAMESPACE \
+                 --set acceptLicenseAgreement=yes \
+                 --set readinessProbe.initialDelaySeconds=20 \
+                 --set livenessProbe.initialDelaySeconds=20 \
+                 --set neo4jPassword=mySecretPassword \
+                 --set core.standalone=true \
+                 -v 3 | tee -a $BUILD_ARTIFACTS/INSTALL-standalone.txt
+                     
+
       - run:
           name: Twiddling our Thumbs
           command: |
-            sleep 60
+            sleep 10
             NAMESPACE=ns-$CIRCLE_BUILD_NUM
             kubectl logs --namespace $NAMESPACE \
               -l "app.kubernetes.io/name=neo4j,app.kubernetes.io/component=core" | tee -a $BUILD_ARTIFACTS/startlogs.txt
 
       - run:
-          name: Wait for GKE deployment to succeed and become ready
+          name: Wait for GKE STANDALONE deployment to succeed and become ready
+          command: |
+              NAMESPACE=ns-$CIRCLE_BUILD_NUM
+              kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME_STANDALONE-neo4j-core --watch | tee -a $BUILD_ARTIFACTS/wait.txt
+      
+      # We're going to test standalone first because it forms faster than cluster.  In the background,
+      # cluster is still forming....
+      - run: 
+          name: Test STANDALONE
+          command: |
+              NAMESPACE=ns-$CIRCLE_BUILD_NUM
+              helm test $NAME_STANDALONE --namespace $NAMESPACE --logs | tee -a $BUILD_ARTIFACTS/TEST-STANDALONE.txt
+
+      - run:
+          name: Wait for GKE CLUSTERED deployment to succeed and become ready
           command: |
              NAMESPACE=ns-$CIRCLE_BUILD_NUM
-             kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME-neo4j-core --watch | tee -a $BUILD_ARTIFACTS/wait.txt
+             kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME-cluster-neo4j-core --watch | tee -a $BUILD_ARTIFACTS/wait.txt
 
       - run:
           name: Test
           command: |
             NAMESPACE=ns-$CIRCLE_BUILD_NUM
-            helm test $NAME --namespace $NAMESPACE --logs | tee -a $BUILD_ARTIFACTS/TEST.txt
+            helm test $NAME_CLUSTERED --namespace $NAMESPACE --logs | tee -a $BUILD_ARTIFACTS/TEST.txt
 
       - run:
           name: Uninstall / Cleanup

--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ report test results, and teardown / destroy PVCs.
 
 #### Standalone
 
+Standalone forms faster so we can manually lower the liveness/readiness timeouts.
+
 ```
 export NAME=a
 export NAMESPACE=default
-helm install $NAME . --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword --set core.standalone=true && \
+helm install $NAME . --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword --set core.standalone=true --set readinessProbe.initialDelaySeconds=20 --set livenessProbe.initialDelaySeconds=20 && \
 kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME-neo4j-core --watch && \
 helm test $NAME --logs | tee testlog.txt
 helm uninstall $NAME

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ This repository contains a Helm chart that starts Neo4j >= 4.0 Enterprise Editio
 
 Check the [releases page](https://github.com/neo4j-contrib/neo4j-helm/releases) and copy the URL of the tgz package.
 
+### Standalone (single server)
+
+```bash
+$ helm install mygraph RELEASE_URL --set core.standalone=true --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword
+```
+
+### Causal Clustere (3 core, 0 read replicas)
+
 ```bash
 $ helm install mygraph RELEASE_URL --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword
 ```
@@ -86,6 +94,22 @@ helm template --name tester --set acceptLicenseAgreement=yes --set neo4jPassword
 The following mini-script will provision a test cluster, monitor it for rollout, test it,
 report test results, and teardown / destroy PVCs.
 
+#### Standalone
+
+```
+export NAME=a
+export NAMESPACE=default
+helm install $NAME . --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword --set core.standalone=true && \
+kubectl rollout status --namespace $NAMESPACE StatefulSet/$NAME-neo4j-core --watch && \
+helm test $NAME --logs | tee testlog.txt
+helm uninstall $NAME
+sleep 20
+for idx in 0 1 2 ; do
+  kubectl delete pvc datadir-$NAME-neo4j-core-$idx ;
+done
+```
+
+#### Causal Cluster
 ```
 export NAME=a
 export NAMESPACE=default

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,10 +1,15 @@
+{{- if and (.Values.core.standalone) (gt (.Values.readReplica.numberOfServers | int) 0)}}
+You have specified standalone mode and also read replicas.  The read replicas argument has
+been ignored - only Neo4j clusters may have read replicas.
+{{- end }}
+
 {{- if and (ne "yes" .Values.acceptLicenseAgreement) (contains "enterprise" .Values.imageTag)}}
 ####   ERROR: You did not accept the Neo4j Enterprise License. ####
 ####   ERROR: Please set acceptLicenseAgreement to yes.        ####
 ###################################################################
 {{- else }}
-Your cluster is now being deployed, and may take up to 5 minutes to become available.
 
+Your cluster is now being deployed, and may take up to 5 minutes to become available.
 If you'd like to track status and wait on your rollout to complete, run:
 
 $ kubectl rollout status --namespace {{ .Release.Namespace }} StatefulSet/{{ template "neo4j.name" . }}-core --watch
@@ -22,7 +27,7 @@ kubectl run -it --rm cypher-shell \
     --image={{ .Values.image }}:{{ .Values.imageTag }} \
     --restart=Never \
     --namespace {{ .Release.Namespace }} \
-    --command -- ./bin/cypher-shell -u neo4j -p "$NEO4J_PASSWORD" -a neo4j://{{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.cluster.overview()"
+    --command -- ./bin/cypher-shell -u neo4j -p "$NEO4J_PASSWORD" -a neo4j://{{ printf "%s-%s" .Release.Name .Values.name | trunc 56 }}.{{ printf "%s" .Release.Namespace }}.svc.cluster.local "call dbms.routing.getRoutingTable({}, 'system');"
 
 This will print out the addresses of the members of the cluster.
 

--- a/templates/core-configmap.yaml
+++ b/templates/core-configmap.yaml
@@ -6,4 +6,9 @@ kind: ConfigMap
 metadata:
   name: {{ template "neo4j.coreConfig.fullname" . }}
 data:
+  {{- if .Values.core.standalone }}
+  # https://neo4j.com/docs/operations-manual/current/reference/configuration-settings/#config_dbms.mode
+  NEO4J_dbms_mode: SINGLE
+  {{- else }}
   NEO4J_dbms_mode: CORE
+  {{- end }}

--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -5,7 +5,11 @@ metadata:
 spec:
   podManagementPolicy: Parallel
   serviceName: {{ template "neo4j.fullname" . }}
+  {{- if .Values.core.standalone }}
+  replicas: 1
+  {{- else }}
   replicas: {{ .Values.core.numberOfServers }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/templates/discovery-lb.yaml
+++ b/templates/discovery-lb.yaml
@@ -1,7 +1,11 @@
 # This creates a discovery Service for each member in the core set, and ties to
 # the use of the Neo4j discovery type "K8S" with the configured selectors.
+# Done as many times as there are core machines, or just once if standalone.
 {{- $dot := . }}
 {{- $times := int .Values.core.numberOfServers }}
+{{- if .Values.core.standalone }}
+{{- $times := int 1 }}
+{{- end }}
 {{- range untilStep 0 $times 1 }}
 ---
 apiVersion: v1

--- a/templates/pod-init-script.yaml
+++ b/templates/pod-init-script.yaml
@@ -83,12 +83,15 @@ data:
       export $setting="$SETTING_VALUE"
     done
 
+    {{- if not .Values.core.standalone }}
+    # This discovery mechanism only applies for clustered installs.
     # These settings are *not* overrideable, because they must match the addresses the
     # core members see to avoid akka rejections, and to facilitate basic cluster formation.
     # K8S discovery requires an LB service per pod, and a service account with permissions to query the discovery API
     export NEO4J_causal__clustering_kubernetes_label__selector="neo4j.com/cluster={{ template "neo4j.fullname" . }},neo4j.com/role=CORE"
     export NEO4J_causal__clustering_discovery__type=K8S
     export NEO4J_causal__clustering_kubernetes_service__port__name="discovery"
+    {{- end }}
 
     if [ "${AUTH_ENABLED:-}" == "true" ]; then
       export NEO4J_AUTH="neo4j/${NEO4J_SECRETS_PASSWORD}"

--- a/templates/readreplicas-configmap.yaml
+++ b/templates/readreplicas-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.core.standalone }}
 # This ConfigMap gets passed to all core cluster members to configure them.
 # Take note that some networking settings like internal hostname still get configured
 # when the pod starts, but most non-networking specific configs can be tailored here.
@@ -7,3 +8,4 @@ metadata:
   name: {{ template "neo4j.replicaConfig.fullname" . }}
 data:
   NEO4J_dbms_mode: READ_REPLICA
+{{- end }}

--- a/templates/readreplicas-deployment.yaml
+++ b/templates/readreplicas-deployment.yaml
@@ -1,3 +1,5 @@
+{{- if not .Values.core.standalone }}
+# The ReadReplica deployment only happens for clustered installs.
 apiVersion: "apps/v1"
 kind: Deployment
 metadata:
@@ -132,3 +134,4 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.imagePullSecret }}
 {{- end -}}
+{{- end }} # if not standalone mode

--- a/templates/readreplicas-dns.yaml
+++ b/templates/readreplicas-dns.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.core.standalone }}
 # This service is intended for clients running in kubernetes to connect to the
 # cluster replica set.  This distinguishes it from discovery-lb which is about 
 # cluster formation and internal communication.
@@ -46,3 +47,4 @@ spec:
     app.kubernetes.io/name: {{ template "neo4j.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/component: replica
+{{- end }}

--- a/templates/readreplicas-hpa.yaml
+++ b/templates/readreplicas-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.readReplica.autoscaling.enabled }}
+{{- if and (not .Values.core.standalone) (.Values.readReplica.autoscaling.enabled) }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/templates/tests/test-script.yaml
+++ b/templates/tests/test-script.yaml
@@ -126,8 +126,11 @@ data:
 
     runtest "Bolt is available, port $PORT_BOLT"               "RETURN 'yes';"
     runtest "Basic read queries"                               "MATCH (n) RETURN COUNT(n);"
-    runtest "Database is in clustered mode"                    "CALL dbms.cluster.overview();" 
     runtest "Cluster accepts writes"                           'CREATE (t:TestNode) RETURN count(t);'
+
+    # Clustering tests...
+    {{- if not .Values.core.standalone }}
+    runtest "Database is in clustered mode"                    "CALL dbms.cluster.overview();" 
 
     # Data from server on cluster topology.
     topology=$(cypher "CALL dbms.cluster.overview();")
@@ -171,13 +174,16 @@ data:
       test="Core host $id of $CORES -- $core_endpoint has APOC installed correctly"
       runtest "$test" "RETURN apoc.version();" "$core_endpoint"
     done
+    {{- end }} # If database in clustered mode
 
     # Test for data replication.
     runtest "Sample canary write" 'CREATE (c:Canary) RETURN count(c);'
     echo "Sleeping a few seconds to permit replication"
     sleep 5
 
+    {{- if not .Values.core.standalone }}
     # Check each core, count the canary writes. They should all agree.
+    # We don't have to do this test for standalone, and note that above we already verified writes.
     for id in $(seq 0 $((CORES - 1))); do
       core_host=$(core_hostname $id)
       # Use bolt driver, not routing driver, to ensure that test verifies data
@@ -199,6 +205,7 @@ data:
         fail "$test" "Canary read failed to execute -- exit code $exit_code / RESULT -- $result"
       fi
     done
+    {{- end }}
 
     echo "All good; testing completed"
     exit 0

--- a/values.yaml
+++ b/values.yaml
@@ -34,7 +34,7 @@ authEnabled: true
 ## Defaults to a random 10-character alphanumeric string if not set and authEnabled is true
 # neo4jPassword:
 
-# Specify cluster domain (used eg. as suffix in definition of NEO4J_causal__clustering_initial__discovery__members environment variable)
+# Specify cluster domain (used eg. as suffix in the eventual internal hostnames)
 clusterDomain: "cluster.local"
 
 # Specs for the images used for running tests against the Helm package
@@ -53,6 +53,7 @@ defaultDatabase: "neo4j"
 # Cores
 core:
   # configMap: "my-custom-configmap"
+  standalone: false
   numberOfServers: 3
   persistentVolume:
     ## whether or not persistence is enabled
@@ -186,6 +187,9 @@ resources: {}
 # that initialDelaySeconds give the cluster time to form, because
 # if readiness probes start immediately after container start,
 # they may end up not forming quickly enough and getting killed.
+# DEPENDENCY:  If you're running in standalone mode, the single machine
+# starts much faster.  You could set initialDelaySeconds to something like
+# 30 and it would be OK for a stand-alone machine, but not for a cluster.
 readinessProbe:
   initialDelaySeconds: 120
   failureThreshold: 3


### PR DESCRIPTION
This PR:

- Introduces `core.standalone=(true|false)` as a way of configuring standalone deploys.   The standalone config was added to the "core" section to help make it explicit that all of the other core pod configuration parameters still apply
- Adds CI testing scenarios for standalone mode
- Disables all read replica related configurations and settings when core.standalone=true
- Adds documentation describing how to use it
- Does *not* change the default mode of operation (lacking args to the contrary, you still get a causal cluster with 3 core members, 0 read replicas)