### PR TITLE
Convert replicas to StatefulSet

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 4.0.5-1
+version: 4.0.5-2
 appVersion: 4.0.5
 description: Neo4j is the world's leading graph database
 keywords:

--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -2,6 +2,12 @@ apiVersion: "apps/v1"
 kind: StatefulSet
 metadata:
   name: "{{ template "neo4j.core.fullname" . }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "neo4j.name" . }}
+    app.kubernetes.io/component: core
 spec:
   podManagementPolicy: Parallel
   serviceName: {{ template "neo4j.fullname" . }}

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -1,7 +1,7 @@
 {{- if not .Values.core.standalone }}
 # The ReadReplica deployment only happens for clustered installs.
 apiVersion: "apps/v1"
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: "{{ template "neo4j.replica.fullname" . }}"
   labels:
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/name: {{ template "neo4j.name" . }}
     app.kubernetes.io/component: replica
 spec:
+  podManagementPolicy: Parallel
+  serviceName: "{{ template "neo4j.replica.fullname" . }}"
 {{- if not .Values.readReplica.autoscaling.enabled }}
   replicas: {{ .Values.readReplica.numberOfServers }}
 {{- end }}
@@ -22,8 +24,10 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ template "neo4j.name" . }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app.kubernetes.io/name: {{ template "neo4j.name" . }}
         app.kubernetes.io/component: replica
     spec:
       serviceAccountName: "{{ template "neo4j.fullname" . }}-sa"
@@ -53,12 +57,7 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
-            # Replicas advertise by bare IP, not hostname.  This is because deployments in kubernetes
-            # don't provide good FQDNs. (https://github.com/kubernetes/kubernetes/issues/60789)
-            # The FQDN advertisement address is necessary for the akka cluster formation in Neo4j to work,
-            # so if you advertise with a bare local hostname or something invalid, the read replica will be
-            # unable to join the raft group.
-            export HOST=$(hostname -i)
+            export replica_idx=$(hostname | sed 's|.*-||')
 
             # Processes key configuration elements and exports env vars we need.
             . /helm-init/init.sh
@@ -69,7 +68,7 @@ spec:
             export NEO4J_causal__clustering_transaction__advertised__address=$HOST:6000
             export NEO4J_causal__clustering_raft__advertised__address=$HOST:7000
 
-            echo "Starting Neo4j READ_REPLICA on $HOST"
+            echo "Starting Neo4j READ_REPLICA $replica_idx on $HOST"
             exec /docker-entrypoint.sh "neo4j"
         ports:
         - containerPort: 5000
@@ -140,11 +139,37 @@ spec:
             items:
             - key: credentials.json
               path: credentials.json
-        {{- end }}    
+        {{- end }}
+        {{- if not .Values.readReplica.persistentVolume.enabled }}
+        - name: datadir
+          emptyDir: {}
+        {{- end }}
         - name: plugins
           emptyDir: {}
 {{- if .Values.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecret }}
 {{- end -}}
+  {{- if .Values.readReplica.persistentVolume.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        annotations:
+        {{- if .Values.readReplica.persistentVolume.annotations }}
+  {{ toYaml .Values.readReplica.persistentVolume.annotations | indent 12 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+      {{- if .Values.readReplica.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.readReplica.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.readReplica.persistentVolume.storageClass }}"
+      {{- end }}
+      {{- end }}
+        resources:
+          requests:
+            storage: "{{ .Values.readReplica.persistentVolume.size }}"
+  {{- end }}
 {{- end }} # if not standalone mode

--- a/templates/tests/test-script.yaml
+++ b/templates/tests/test-script.yaml
@@ -14,7 +14,7 @@ data:
   run.sh: |-
     export PATH=/usr/bin:$PATH
     export host="$NAME-neo4j.$NAMESPACE.svc.cluster.local"
-    export replica_host="$NAME-readreplica-svc.$NAMESPACE.svc.cluster.local"
+    export replica_host="$NAME-neo4j.$NAMESPACE.svc.cluster.local"
     echo "HOST $host"
     # This endpoint proves availability of the overall service
     export endpoint="http://$host:$PORT_HTTP"
@@ -53,6 +53,10 @@ data:
     function core_hostname {
       # Example: a-neo4j-core-0.a-neo4j.default.svc.cluster.local
       echo "$NAME-neo4j-core-$1.$NAME-neo4j.$NAMESPACE.svc.cluster.local"
+    }
+
+    function replica_hostname {
+      echo "{{ .Release.Name }}-neo4j-replica-$1.{{ .Release.Name }}-neo4j-replica.{{ .Release.Namespace }}.svc.cluster.local"
     }
 
     test_index=0
@@ -174,6 +178,13 @@ data:
       test="Core host $id of $CORES -- $core_endpoint has APOC installed correctly"
       runtest "$test" "RETURN apoc.version();" "$core_endpoint"
     done
+
+    # Replicas are up and configured.
+    if [ "$READ_REPLICAS" -gt 0 ]; then 
+      replica_endpoint="bolt://$replica_host:$PORT_BOLT"
+      test="Replica host -- $replica_endpoint is available"
+      runtest "$test" "MATCH (n) RETURN COUNT(n);" "$replica_endpoint"
+    fi
     {{- end }} # If database in clustered mode
 
     # Test for data replication.
@@ -204,6 +215,31 @@ data:
       else
         fail "$test" "Canary read failed to execute -- exit code $exit_code / RESULT -- $result"
       fi
+    done
+
+    echo "Now testing read replicas"
+
+    for id in $(seq 0 $((READ_REPLICAS - 1))); do
+      replica=$(replica_hostname $id)
+      replica_ep="bolt://$replica:$PORT_BOLT"
+      test "Replica host $id has the canary write"
+      result=$(cypher "MATCH (c:Canary) WITH count(c) as x where x = 1 RETURN x;" "$replica_ep")
+      exit_code=$?
+      if [ $exit_code -eq 0 ] ; then
+        # Check that the data is there.
+        found_results=$(echo "$result" | grep -o 1 | wc -l)
+
+        if [ $found_results -eq 1 ] ; then
+          succeed "$test"
+        else 
+          fail "$test" "Canary read did not return data -- $found_results found results from $result"
+        fi
+      else
+        fail "$test" "Canary read failed to execute -- exit code $exit_code / RESULT -- $result"
+      fi
+
+      test="Replica host $id of $READ_REPLICAS -- $replica_ep has APOC installed correctly"
+      runtest "$test" "RETURN apoc.version();" "$replica_ep"
     done
     {{- end }}
 

--- a/user-guide/USER-GUIDE.md
+++ b/user-guide/USER-GUIDE.md
@@ -119,6 +119,7 @@ their default values.
 | `readReplica.autoscaling.minReplicas` | Min replicas for autoscaling  | `1`  |
 | `readReplica.autoscaling.maxReplicas`  | Max replicas for autoscaling  | `3` |
 | `readReplica.initContainers`          | Init containers to add to the replica pods. Example use case is a script that installs custom plugins/extensions                        | `{}`                                            |
+| `readReplica.persistentVolume.*`       | See `core.persistentVolume.*` settings; they behave identically for read replicas                                                      | `true`                                          |
 | `readReplica.service.type` | Service type | `ClusterIP` |
 | `readReplica.service.annotations` | Service annotations | `{}` |
 | `readReplica.service.labels` | Custom Service labels | `{}` |

--- a/user-guide/USER-GUIDE.md
+++ b/user-guide/USER-GUIDE.md
@@ -6,6 +6,13 @@ Neo4j-helm allows users to deploy multi-node Neo4j Enterprise Causal Clusters to
 
 This guide is intended only as a supplement to the [Neo4j Operations Manual](https://neo4j.com/docs/operations-manual/4.0/?ref=googlemarketplace).   Neo4j-helm is essentially a docker container based deploy of Neo4j Causal Cluster.  As such, all of the information in the Operations Manual applies to its operation, and this guide will focus only on kubernetes-specific concerns.
 
+## Architecture
+
+In addition to the information in this user guide, a set of slides is available on the
+deployment architecture and chart structure of this repository.
+
+* [Neo4j Helm Chart Structure](https://docs.google.com/presentation/d/14ziuwTzB6O7cp7fq0mA1lxWwZpwnJ9G4pZiwuLxBK70/edit?usp=sharing)
+
 ## Prerequisites
 
 * Kubernetes 1.6+ with Beta APIs enabled

--- a/values.yaml
+++ b/values.yaml
@@ -143,6 +143,11 @@ readReplica:
     maxReplicas: 3
 
   numberOfServers: 0
+  persistentVolume:
+    enabled: true
+    mountPath: /data
+    size: 10Gi
+    ## subPath: ""
 
   sidecarContainers: []
   ## Additional containers to be added to the Neo4j replica pod.


### PR DESCRIPTION
* Replicas are now a StatefulSet and not a deployment
* Makes hostnames predictable, greatly eases external exposure
* Backs pods with stable disks, which makes them subject to restore pod targeting
* Stable state backing the pod means that catch-up is easier in the cluster
* Improved testing for replicas