### PR TITLE
Added existingPasswordSecret Helm configuration option

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -50,7 +50,11 @@ spec:
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:
               secretKeyRef:
+                {{- if .Values.existingPasswordSecret }}
+                name: {{ .Values.existingPasswordSecret }}
+                {{- else }}
                 name: {{ template "neo4j.secrets.fullname" . }}
+                {{- end}}
                 key: neo4j-password
           {{- end }}      
         command:

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -50,7 +50,11 @@ spec:
           - name: NEO4J_SECRETS_PASSWORD
             valueFrom:
               secretKeyRef:
+                {{- if .Values.existingPasswordSecret }}
+                name: {{ .Values.existingPasswordSecret }}
+                {{- else }}
                 name: {{ template "neo4j.secrets.fullname" . }}
+                {{- end}}
                 key: neo4j-password
           {{- end }}
         command:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authEnabled -}}
+{{- if and (.Values.authEnabled) (not .Values.existingPasswordSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/tests/tester.yaml
+++ b/templates/tests/tester.yaml
@@ -43,7 +43,11 @@ spec:
   volumes:
     - name: secret-volume
       secret:
-        secretName: "{{ template "neo4j.secrets.fullname" . }}"
+        {{- if .Values.existingPasswordSecret }}
+        secretName: {{ .Values.existingPasswordSecret }}
+        {{- else }}
+        secretName: {{ template "neo4j.secrets.fullname" . }}
+        {{- end}}
         items:
           - key: neo4j-password
             path: neo4j-password

--- a/user-guide/USER-GUIDE.md
+++ b/user-guide/USER-GUIDE.md
@@ -130,6 +130,7 @@ their default values.
 | `resources`                           | Resources required (e.g. CPU, memory)                                                                                                   | `{}`                                            |
 | `clusterDomain`                       | Cluster domain                                                                                                                          | `cluster.local`                                 |
 | `restoreSecret`                       | The name of the kubernetes secret to mount to `/creds` in the container.  Please see the [restore documentation](../tools/restore/README-RESTORE.md) for how to use this. | (none) |
+| `existingPasswordSecret`              | The name of the kubernetes secret which contains the `neo4j-password` | (none) |
 
 ## Backup
 

--- a/values.yaml
+++ b/values.yaml
@@ -34,6 +34,9 @@ authEnabled: true
 ## Defaults to a random 10-character alphanumeric string if not set and authEnabled is true
 # neo4jPassword:
 
+## Specify secret name containing the password for neo4j user
+# existingPasswordSecret
+
 # Specify cluster domain (used eg. as suffix in the eventual internal hostnames)
 clusterDomain: "cluster.local"
 


### PR DESCRIPTION
When doing GitOps with ArgoCD, the usage of the secret is not intuitive. I either need to:
- Hardcode the password in the values.yaml (bad pratice because this file is on Github)
- Or ArgoCD continuously syncs and changes the password because it is randomly generated.

Therefore I've created an existingPasswordSecret configuration option which points to an existing secret.
This secret then can also be a sealed secret that will be created by ArgoCD.