### PR TITLE
Add persistent volume definition for read replica

### DIFF
--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -102,6 +102,11 @@ spec:
           mountPath: /helm-init
         - name: plugins
           mountPath: /plugins
+        - name: datadir
+          mountPath: "{{ .Values.readReplica.persistentVolume.mountPath }}"
+          {{- if .Values.readReplica.persistentVolume.subPath }}
+          subPath: {{ .Values.readReplica.persistentVolume.subPath }}
+          {{- end }}
         {{- if .Values.restoreSecret }}
         - name: creds
           mountPath: /auth


### PR DESCRIPTION
The datadir persistent volume might be configured in the same way for cores and replicas.