### PR TITLE
Support additional volumes inside the containers

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -115,6 +115,9 @@ spec:
           mountPath: /auth
           readOnly: true
         {{- end }}  
+        {{- if .Values.core.additionalVolumeMounts }}
+{{ toYaml .Values.core.additionalVolumeMounts | indent 8}}
+        {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
@@ -150,6 +153,9 @@ spec:
         {{- end }}
         - name: plugins
           emptyDir: {}
+        {{- if .Values.core.additionalVolumes }}
+{{ toYaml .Values.core.additionalVolumes | indent 8}}
+        {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -112,6 +112,9 @@ spec:
           mountPath: /auth
           readOnly: true
         {{- end }}
+        {{- if .Values.readReplica.additionalVolumeMounts }}
+{{ toYaml .Values.readReplica.additionalVolumeMounts | indent 8}}
+        {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:
@@ -155,6 +158,9 @@ spec:
         {{- end }}
         - name: plugins
           emptyDir: {}
+        {{- if .Values.readReplica.additionalVolumes }}
+{{ toYaml .Values.readReplica.additionalVolumes | indent 8}}
+        {{- end }}
 {{- if .Values.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecret }}

--- a/values.yaml
+++ b/values.yaml
@@ -127,6 +127,14 @@ core:
     labels: {}
     loadBalancerSourceRanges: []
 
+  ## specify additional volumes to mount in the core container, this can be used
+  ## to specify additional storage of material or to inject files from ConfigMaps
+  ## into the running container
+  additionalVolumes: {}
+
+  ## specify where the additional volumes are mounted in the core container
+  additionalVolumeMounts: {}
+
 # Read Replicas
 readReplica:
   # configMap: "my-custom-configmap"
@@ -183,6 +191,15 @@ readReplica:
     annotations: {}
     labels: {}
     loadBalancerSourceRanges: []
+
+  ## specify additional volumes to mount in the read replica container, this can
+  ## be used to specify additional storage of material or to inject files from
+  ## ConfigMaps into the running container
+  additionalVolumes: {}
+
+  ## specify where the additional volumes are mounted in the read replica
+  ## container
+  additionalVolumeMounts: {}
 
 resources: {}
   # limits:


### PR DESCRIPTION
Add ability to specify additional volumes inside the containers so that
they can be utilised and mounted at various locations inside the pod as
needed.

This will need testing and verification.