### PR TITLE
Issue 65 pod annotations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,10 +157,10 @@ jobs:
              # Prove log persistence
              NAMESPACE=ns-$CIRCLE_BUILD_NUM
              for idx in 0 1 2 ; do 
-                kubectl --namespace $NAMESPACE exec $NAME_CLUSTERED-neo4j-core-$idx /bin/cat /data/logs/debug.log > $BUILD_ARTIFACTS/core-$idx-debug.log ; 
+                kubectl --namespace $NAMESPACE exec $NAME_CLUSTERED-neo4j-core-$idx -- /bin/cat /data/logs/debug.log > $BUILD_ARTIFACTS/core-$idx-debug.log ; 
              done
 
-             kubectl --namespace $NAMESPACE exec $NAME_CLUSTERED-neo4j-replica-0 /bin/cat /data/logs/debug.log > $BUILD_ARTIFACTS/replica-0-debug.log
+             kubectl --namespace $NAMESPACE exec $NAME_CLUSTERED-neo4j-replica-0 -- /bin/cat /data/logs/debug.log > $BUILD_ARTIFACTS/replica-0-debug.log
 
       - run: 
           name: Verify that backup succeeded

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,23 +92,14 @@ jobs:
              cp *.tgz $BUILD_ARTIFACTS/
 
              echo "Installing $chart_archive (CAUSAL CLUSTER TEST SCENARIO)"
-             helm install $NAME_CLUSTERED $chart_archive \
+             helm install $NAME_CLUSTERED -f deployment-scenarios/ci/cluster.yaml $chart_archive \
                  --namespace $NAMESPACE \
-                 --set acceptLicenseAgreement=yes \
-                 --set neo4jPassword=mySecretPassword \
-                 --set readReplica.numberOfServers=1 \
                  -v 3 | tee -a $BUILD_ARTIFACTS/INSTALL-cluster.txt
 
              echo "Installing $chart_archive (STANDALONE SCENARIO)"
-             helm install $NAME_STANDALONE $chart_archive \
+             helm install $NAME_STANDALONE -f deployment-scenarios/ci/standalone.yaml $chart_archive \
                  --namespace $NAMESPACE \
-                 --set acceptLicenseAgreement=yes \
-                 --set readinessProbe.initialDelaySeconds=20 \
-                 --set livenessProbe.initialDelaySeconds=20 \
-                 --set neo4jPassword=mySecretPassword \
-                 --set core.standalone=true \
-                 -v 3 | tee -a $BUILD_ARTIFACTS/INSTALL-standalone.txt
-                     
+                 -v 3 | tee -a $BUILD_ARTIFACTS/INSTALL-standalone.txt                     
 
       #- run:
       #    name: Twiddling our Thumbs

--- a/deployment-scenarios/ci/cluster.yaml
+++ b/deployment-scenarios/ci/cluster.yaml
@@ -1,0 +1,17 @@
+acceptLicenseAgreement: "yes"
+neo4jPassword: mySecretPassword
+
+readReplica:
+    numberOfServers: 1
+
+core:
+    numberOfServers: 3
+    standalone: true
+
+podAnnotations:
+    ci-test: "true"
+
+podLabels:
+    ci-test: "true"
+    hello: world
+    

--- a/deployment-scenarios/ci/cluster.yaml
+++ b/deployment-scenarios/ci/cluster.yaml
@@ -6,7 +6,6 @@ readReplica:
 
 core:
     numberOfServers: 3
-    standalone: true
 
 podAnnotations:
     ci-test: "true"

--- a/deployment-scenarios/ci/standalone.yaml
+++ b/deployment-scenarios/ci/standalone.yaml
@@ -1,0 +1,19 @@
+acceptLicenseAgreement: "yes"
+neo4jPassword: mySecretPassword
+
+readinessProbe:
+   initialDelaySeconds: 20
+
+livenessProbe:
+   initialDelaySeconds: 20
+
+core:
+    standalone: true
+
+podAnnotations:
+    ci-test: "true"
+
+podLabels:
+    ci-test: "true"
+    hello: world
+    

--- a/deployment-scenarios/cluster-custom-labels-annotations.yaml
+++ b/deployment-scenarios/cluster-custom-labels-annotations.yaml
@@ -1,0 +1,19 @@
+# This scenario deploys a cluster with
+# 3 core members and 1 read replica.
+acceptLicenseAgreement: "yes"
+neo4jPassword: "mySecretPassword"
+
+core:
+    standalone: false
+    numberOfServers: 3
+
+readReplica:
+    numberOfServers: 1
+
+podAnnotations:
+    sidecar.istio.io/inject: "false"
+    my-custom-annotation: 24
+
+podLabels:
+    example: "label"
+    second: "example"

--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -30,12 +30,12 @@ spec:
         app.kubernetes.io/name: {{ template "neo4j.name" . }}
         app.kubernetes.io/component: core
         {{-  range $key, $value := .Values.podLabels }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
         {{-  range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{- end }}
       {{- end }}
     spec:

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -30,12 +30,12 @@ spec:
         app.kubernetes.io/name: {{ template "neo4j.name" . }}
         app.kubernetes.io/component: replica
         {{-  range $key, $value := .Values.podLabels }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
         {{-  range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: "{{ $value }}"
         {{- end }}
       {{- end }}
     spec:


### PR DESCRIPTION
- Because of the key/value inclusion technique for custom labels/annotations, quotation marks were getting stripped, leading to errors with some data types.  Simple toYaml inclusion doesn't work due to different templating errors, so this fix makes it possible to include any string values.
- Added deployment examples on custom annotations/labels, but also switched the CI system to deploy the test cases from deployment examples, rather than via `--set` on the helm CLI