### PR TITLE
Quote CPU specs in commented-out defaults

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -150,10 +150,10 @@ readReplica:
 
   resources: {}
   # limits:
-  #   cpu: 100m
+  #   cpu: "100m"
   #   memory: 512Mi
   # requests:
-  #   cpu: 100m
+  #   cpu: "100m"
   #   memory: 512Mi
 
   autoscaling:
@@ -212,10 +212,10 @@ readReplica:
 
 resources: {}
   # limits:
-  #   cpu: 1000m
+  #   cpu: "1000m"
   #   memory: 1G
   # requests:
-  #   cpu: 1000m
+  #   cpu: "1000m"
   #   memory: 1G
 
 # Readiness probes will send a kill signal to the container if


### PR DESCRIPTION
Recently I advised someone to amend this to the number `32` where `"32"` was the correct format.

I'm not sure this is correct, but if it is it seems useful to use the correct format in this place.