### PR TITLE
Fix reference to core member resources metadata in statefulset template

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -134,7 +134,7 @@ spec:
         livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 10 }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.core.resources | indent 10 }}
 {{- if .Values.core.sidecarContainers }}
 {{ toYaml .Values.core.sidecarContainers | indent 6 }}
 {{- end }}


### PR DESCRIPTION
This template reference doesn't grab the core.resources map in the `values.yaml` file since it's using an incorrect reference. 

See the readReplica statefulset file for an example where it properly references the readReplica resources config map.