### PR TITLE
Use correct param name in README's `helm template`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ helm test mygraph
 To see what helm will actually deploy based on the templates:
 
 ```
-helm template --name tester --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword . > expanded.yaml
+helm template --name-template tester --set acceptLicenseAgreement=yes --set neo4jPassword=mySecretPassword . > expanded.yaml
 ```
 
 ### Full-Cycle Test


### PR DESCRIPTION
The correct param name is `--name-template`, not `--name`.