### PR TITLE
Make ServiceAccount configurable

### DIFF
--- a/doc/docs/modules/ROOT/pages/configreference.adoc
+++ b/doc/docs/modules/ROOT/pages/configreference.adoc
@@ -53,6 +53,14 @@ Reference tables with a list of all configurable parameters and their defaults.
 | Extra / custom annotations to apply to core & replica statefulset pods. 
 | `{}`
 
+| `serviceAccount.annotations`
+| Extra / custom annotations to apply to core & replica service account.
+| `{}`
+
+| `serviceAccount.name`
+| Custom core & replica service account name. If empty, name will be generated from the chart's fullname.
+| (none)
+
 |===
 
 ## Neo4j Core Members

--- a/doc/docs/modules/ROOT/pages/operations.adoc
+++ b/doc/docs/modules/ROOT/pages/operations.adoc
@@ -173,3 +173,7 @@ If scaling down, do not scale below three core nodes; this is the minimum necess
 For productionized installs, anti-affinity rules are recommended, where pod deployment is intentionally spread out among Kubernetes worker nodes. This improves Neo4j's failure characteristics. If Kubernetes inadvertently deploys all 3 core Neo4j pods to a single worker node, and the underlying worker node VM fails -- then the entire cluster will go down. For this reason, anti-affinity rules are recommended to "spread the deployment out".
 
 An example of how to configure this with references to documentation is provided in the deployment scenarios directory.
+
+## Service account annotation
+
+The helm chart settings which allow to annotate the service account used by core & replica services. This allows to bind the Kubernetes service account to a cloud IAM role for better security. Refer to the documentation for [AWS](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html) and [GCP](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for more details.

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -1,4 +1,5 @@
 ---
+{{- $saName := print (include "neo4j.fullname" .) "-sa" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,7 +9,7 @@ metadata:
       {{ $key }}: "{{ $value }}"
       {{- end }}
     {{- end }}
-    name: {{ tpl .Values.serviceAccount.name . }}
+    name: {{ default $saName .Values.serviceAccount.name  }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -25,7 +26,7 @@ metadata:
     name: {{ template "neo4j.fullname" . }}-sa-to-service-reader-binding
 subjects:
     - kind: ServiceAccount
-      name: {{ template "neo4j.fullname" . }}-sa
+      name: {{ default $saName .Values.serviceAccount.name  }}
 roleRef:
     # "roleRef" specifies the binding to a Role / ClusterRole
     kind: Role # this must be Role or ClusterRole

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -2,7 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    name: {{ template "neo4j.fullname" . }}-sa
+    {{- if .Values.serviceAccount.annotations }}
+    annotations:
+      {{-  range $key, $value := .Values.serviceAccount.annotations }}
+      {{ $key }}: "{{ $value }}"
+      {{- end }}
+    {{- end }}
+    name: {{ tpl .Values.serviceAccount.name . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/values.yaml
+++ b/values.yaml
@@ -298,3 +298,7 @@ dbms:
       max_size: ""
     pagecache:
       size: ""
+
+serviceAccount:
+  annotations: {}
+  name: '{{ template "neo4j.fullname" . }}-sa'

--- a/values.yaml
+++ b/values.yaml
@@ -301,4 +301,5 @@ dbms:
 
 serviceAccount:
   annotations: {}
-  name: '{{ template "neo4j.fullname" . }}-sa'
+  # If empty, name will be generated from the chart's fullname
+  name:


### PR DESCRIPTION
This PR makes the creation of the Service Account more configurable. This is a requirement when using [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) or [AWS STS](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html) as described in https://github.com/neo4j-contrib/neo4j-helm/issues/129#issuecomment-726904072.