### PR TITLE
Add support for pod labels in backup

### DIFF
--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -16,6 +16,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{-  range $key, $value := .Values.podLabels }}
+            {{ $key }}: "{{ $value }}"
+            {{- end }}
         spec:
           restartPolicy: Never
           containers:

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -1,5 +1,6 @@
 image: gcr.io/neo4j-helm/backup
 imageTag: 4.2.0-1
+podLabels: {}
 neo4jaddr: holder-neo4j.default.svc.cluster.local:6362
 # In case of azure the bucket is used as the container where the backup is stored
 # bucket: azure-storage-container


### PR DESCRIPTION
We need pod labels on the backup to be able to implement network security policies.

Got some new line changes by editing in the browser editor without doing actual changes so leaving those changes.