### PR TITLE
Make RBAC & serviceAccount creation configurable

### DIFF
--- a/doc/docs/modules/ROOT/pages/configreference.adoc
+++ b/doc/docs/modules/ROOT/pages/configreference.adoc
@@ -57,6 +57,14 @@ Reference tables with a list of all configurable parameters and their defaults.
 | Extra / custom annotations to apply to core & replica statefulset pods.
 | `{}`
 
+| `rbac.create`
+| Whether to create Role & RoleBinding for this chart.
+| `true`
+
+| `serviceAccount.create`
+| Whether to create a ServiceAccount for this chart.
+| `true`
+
 | `serviceAccount.annotations`
 | Extra / custom annotations to apply to core & replica service account.
 | `{}`

--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $saName := print (include "neo4j.fullname" .) "-sa" -}}
 apiVersion: "apps/v1"
 kind: StatefulSet
 metadata:
@@ -39,7 +40,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccountName: "{{ template "neo4j.fullname" . }}-sa"
+      serviceAccountName: {{ default $saName .Values.serviceAccount.name }}
       # High value permits checkpointing on Neo4j shutdown.  See: https://neo4j.com/developer/kb/checkpointing-and-log-pruning-interactions/
       terminationGracePeriodSeconds: {{ .Values.core.terminationGracePeriodSeconds }}
       containers:

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $saName := print (include "neo4j.fullname" .) "-sa" -}}
 {{- if not .Values.core.standalone }}
 # The ReadReplica deployment only happens for clustered installs.
 apiVersion: "apps/v1"
@@ -39,7 +40,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      serviceAccountName: "{{ template "neo4j.fullname" . }}-sa"
+      serviceAccountName: {{ default $saName .Values.serviceAccount.name }}
       # High value permits checkpointing on Neo4j shutdown.  See: https://neo4j.com/developer/kb/checkpointing-and-log-pruning-interactions/
       terminationGracePeriodSeconds: {{ .Values.readReplica.terminationGracePeriodSeconds }}
       containers:

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -1,5 +1,6 @@
----
 {{- $saName := print (include "neo4j.fullname" .) "-sa" -}}
+{{- if .Values.serviceAccount.create -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,6 +11,8 @@ metadata:
       {{- end }}
     {{- end }}
     name: {{ default $saName .Values.serviceAccount.name  }}
+{{- end }}
+{{- if .Values.rbac.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -32,3 +35,4 @@ roleRef:
     kind: Role # this must be Role or ClusterRole
     name: {{ template "neo4j.fullname" . }}-service-reader # this must match the name of the Role or ClusterRole you wish to bind to
     apiGroup: rbac.authorization.k8s.io
+{{- end}}

--- a/values.yaml
+++ b/values.yaml
@@ -301,6 +301,7 @@ dbms:
     pagecache:
       size: ""
 
+# Create Role and RoleBinding
 rbac:
   create: true
 

--- a/values.yaml
+++ b/values.yaml
@@ -301,7 +301,11 @@ dbms:
     pagecache:
       size: ""
 
+rbac:
+  create: true
+
 serviceAccount:
+  create: true
   annotations: {}
   # If empty, name will be generated from the chart's fullname
   name:


### PR DESCRIPTION
In order to deploy neo4j into more secured Kubernetes clusters (ones that don't allow the creation of RBAC resources nor service accounts) we allow the ability to bypass the creation of such resources. This does not change current behavior; said resources will still be created by default.