### PR TITLE
Fixing password propagation in the secret template

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -3,13 +3,13 @@
 {{ $password := randAlphaNum 10 | b64enc | quote }}
 
 {{- if .Values.neo4jPassword }}
-{{ $password := .Values.neo4jPassword }}
+{{ $password = .Values.neo4jPassword | b64enc | quote }}
 {{- end -}}
 
 {{- $name := include "neo4j.secrets.fullname" . }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace $name) }}
 {{- if $secret }}
-{{ $password := index $secret.data "neo4j-password" }}
+{{ $password = index $secret.data "neo4j-password" }}
 {{- end -}}
 
 apiVersion: v1


### PR DESCRIPTION
This PR fixes the issue that the `.Values.neo4jPassword` is not used when defined and random password is always used instead. The password should also be base64 encoded.