### PR TITLE
Fixing condition for plugins

### DIFF
--- a/templates/common-configmap.yaml
+++ b/templates/common-configmap.yaml
@@ -30,7 +30,7 @@ data:
   NEO4J_metrics_csv_enabled: "{{ .Values.metrics.csv.enabled }}"
   NEO4J_metrics_csv_interval: "{{ .Values.metrics.csv.interval }}"
   NEO4J_metrics_jmx_enabled: "{{ .Values.metrics.jmx.enabled }}"
-  {{- if "{{ .Values.plugins }}" }}
+  {{- if .Values.plugins }}
   NEO4JLABS_PLUGINS: {{ .Values.plugins | toJson }}
   NEO4J_apoc_import_file_use__neo4j__config: "true"
   {{- end }}


### PR DESCRIPTION
This PR is fixing the condition that is verifying is there are any plugins defined via `.Values.plugins`. Without this patch, the condition is always `true` even if the value is empty string or `null`.