### PR TITLE
add support for transaction memory allocation and transaction memory limits

### DIFF
--- a/deployment-scenarios/standalone-custom-memory-config.yaml
+++ b/deployment-scenarios/standalone-custom-memory-config.yaml
@@ -16,7 +16,11 @@ dbms:
             initial_size: 1024m
             max_size: 1024m
         pagecache:
-            size: 567m
+            size: 123m
+        transaction:
+            memory_allocation: ON_HEAP
+            max_size: 60m
+            global_max_size: 200m
 
 acceptLicenseAgreement: "yes"
 neo4jPassword: mySecretPassword

--- a/doc/docs/modules/ROOT/pages/operations.adoc
+++ b/doc/docs/modules/ROOT/pages/operations.adoc
@@ -32,6 +32,9 @@ You may set any of the following settings. The helm chart accepts these settings
 * `dbms.memory.heap.initial_size`
 * `dbms.memory.heap.max_size`
 * `dbms.memory.pagecache.size`
+* `dbms.memory.transaction.memory_allocation`
+* `dbms.memory.transaction.max_size`
+* `dbms.memory.transaction.global_max_size`
 
 Their meanings, formats, and defaults are the same as found in the operations manual. See the section "Passing Custom Configuration as a ConfigMap" for how to set these settings for your database.
 

--- a/templates/pod-init-script.yaml
+++ b/templates/pod-init-script.yaml
@@ -79,8 +79,20 @@ data:
       {{- end }}
 
       {{- if .Values.dbms.memory.pagecache.size }}
-      NEO4J_SETTINGS[NEO4J_dbms_memory_pagecache_size]={{ .Values.dbms.memory.pagecache.size}}
+      NEO4J_SETTINGS[NEO4J_dbms_memory_pagecache_size]={{ .Values.dbms.memory.pagecache.size }}
       {{- end }}
+
+      {{- if .Values.dbms.memory.transaction.max_size }}
+      NEO4J_SETTINGS[NEO4J_dbms_memory_transaction_max__size]={{ .Values.dbms.memory.transaction.max_size }}
+      {{- end }}
+
+      {{- if .Values.dbms.memory.transaction.global_max_size }}
+      NEO4J_SETTINGS[NEO4J_dbms_memory_transaction_global__max__size]={{ .Values.dbms.memory.transaction.global_max_size }}
+      {{- end }}
+
+      {{ - if .Values.dbms.memory.transaction.memory_allocation }}
+      NEO4J_SETTINGS[NEO4J_dbms_tx__state_memory__allocation]={{ .Values.dbms.memory.transaction.memory_allocation }}
+      {{ - end }}
     {{- end }}
 
     echo "Configuration override prefix = $override_prefix"

--- a/values.yaml
+++ b/values.yaml
@@ -300,6 +300,13 @@ dbms:
       max_size: ""
     pagecache:
       size: ""
+    transaction:
+      memory_allocation: ""
+      # maximum size of an individual transaction
+      max_size: ""
+      # maximum size of all transactions combined
+      global_max_size: ""
+
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
this allows for more fine tuning of neo4j memory configuration which is particularly useful for small-memory-allocation scenarios