### PR TITLE
improvements to backup and restore

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -154,9 +154,11 @@ spec:
             {{- if .Values.core.persistentVolume.subPath }}
             subPath: {{ .Values.core.persistentVolume.subPath }}
             {{- end }}
+          {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
           - name: credentials
             mountPath: /credentials
             readOnly: true
+          {{- end }}
         env:
           - name: DATABASE
             value: {{ .Values.core.restore.database }}
@@ -180,14 +182,14 @@ spec:
         - name: init-script
           configMap:
             name: "{{ .Release.Name }}-init-script"
-        {{ if .Values.core.restore.enabled }}
+        {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
         - name: credentials
           secret:
             secretName: {{ .Values.core.restore.secretName }}
             items:
               - key: credentials
                 path: credentials
-        {{ end }}
+        {{- end }}
         {{- if not .Values.core.persistentVolume.enabled }}
         - name: datadir
           emptyDir: {}

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -146,9 +146,11 @@ spec:
             {{- if .Values.core.persistentVolume.subPath }}
             subPath: {{ .Values.core.persistentVolume.subPath }}
             {{- end }}
+          {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
           - name: credentials
             mountPath: /credentials
             readOnly: true
+          {{- end }}
         env:
           - name: DATABASE
             value: {{ .Values.readReplica.restore.database }}
@@ -184,14 +186,14 @@ spec:
         - name: init-script
           configMap:
             name: "{{ .Release.Name }}-init-script"
-        {{ if .Values.readReplica.restore.enabled }}
+        {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
         - name: credentials
           secret:
             secretName: {{ .Values.readReplica.restore.secretName }}
             items:
               - key: credentials
                 path: credentials
-        {{ end }}
+        {{- end }}
         {{- if not .Values.readReplica.persistentVolume.enabled }}
         - name: datadir
           emptyDir: {}

--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -180,12 +180,16 @@ function backup_database() {
 }
 
 function activate_gcp() {
-  echo "Activating google credentials before beginning"
-  gcloud auth activate-service-account --key-file "/credentials/credentials"
-
-  if [ $? -ne 0 ]; then
-    echo "Credentials failed; no way to copy to google."
-    exit 1
+  local credentials="/credentials/credentials"
+  if [[ -f "${credentials}" ]]; then
+    echo "Activating google credentials before beginning"
+    gcloud auth activate-service-account --key-file "${credentials}"
+    if [ $? -ne 0 ]; then
+      echo "Credentials failed; no way to copy to google."
+      exit 1
+    fi
+  else
+    echo "No credentials file found. Assuming workload identity is configured"
   fi
 }
 

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -26,6 +26,9 @@ spec:
             {{ $key }}: "{{ $value }}"
             {{- end }}
         spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
           restartPolicy: Never
           shareProcessNamespace: {{ .Values.shareProcessNamespace }}
           containers:
@@ -57,13 +60,16 @@ spec:
                   value: "{{ .Values.checkLabelScanStore }}"
                 - name: CHECK_PROPERTY_OWNERS
                   value: "{{ .Values.checkPropertyOwners }}"
+              {{- if .Values.secretName }}
               volumeMounts:
                 - name: credentials
                   mountPath: /credentials
                   readOnly: true
+              {{- end }}
 {{- if .Values.sidecarContainers }}
 {{ toYaml .Values.sidecarContainers | indent 12 }}
 {{- end }}
+{{- if .Values.secretName }}
           volumes:
             - name: credentials
               secret:
@@ -71,3 +77,4 @@ spec:
                 items:
                   - key: credentials
                     path: credentials
+{{- end }}

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -28,6 +28,8 @@ spec:
         spec:
           {{- if .Values.serviceAccountName }}
           serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- /* explicitly mount token because some service accounts disable automount-by-default and require explicit opt-in */}}
+          automountServiceAccountToken: true
           {{- end }}
           restartPolicy: Never
           shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -9,6 +9,7 @@ bucket: gs://test-neo4j
 database: neo4j,system
 # cloudProvider can be either gcp, aws, or azure
 cloudProvider: gcp
+# set secretName to NULL if using workload-identity in gcp
 secretName: "neo4j-gcp-credentials"
 pageCache: 2G
 heapSize: 2G
@@ -19,6 +20,9 @@ checkGraph: "true"
 checkLabelScanStore: "true"
 checkPropertyOwners: "false"
 jobSchedule: "0 */12 * * *"
+
+# Set to name of an existing Service Account to use if desired
+serviceAccountName: ""
 
 # When running in mesh
 shareProcessNamespace: false # Needs to be true for the below example configuration to work

--- a/tools/restore/Dockerfile
+++ b/tools/restore/Dockerfile
@@ -1,24 +1,20 @@
-FROM launcher.gcr.io/google/debian9
-RUN apt-get update
-RUN apt-get install -y bash curl wget gnupg apt-transport-https apt-utils lsb-release
-RUN wget -O - https://debian.neo4j.com/neotechnology.gpg.key | apt-key add -
-RUN echo 'deb https://debian.neo4j.com stable 4.2' | tee -a /etc/apt/sources.list.d/neo4j.list
+FROM neo4j:4.2.2-enterprise
+RUN apt-get update \
+ && apt-get install -y curl wget gnupg apt-transport-https apt-utils lsb-release unzip less \
+ && rm -rf /var/lib/apt/lists/*
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN echo "deb http://httpredir.debian.org/debian stretch-backports main" | tee -a /etc/apt/sources.list.d/stretch-backports.list
 
-RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selections
-RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
-
-RUN apt-get update && apt-get install -y neo4j-enterprise=1:4.2.2
-RUN apt-get install -y google-cloud-sdk unzip less
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
+RUN apt-get update && apt-get install -y google-cloud-sdk && rm -rf /var/lib/apt/lists/*
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+ && unzip awscliv2.zip && rm awscliv2.zip \
+ && ./aws/install
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-RUN mkdir /data
+RUN mkdir -p /data
 ADD restore/restore.sh /scripts/restore.sh
 RUN chmod +x /scripts/restore.sh
 
+ENTRYPOINT ["bash"]
 CMD ["/scripts/restore.sh"]


### PR DESCRIPTION
 - set `neo4j-admin restore`'s `--to-data-directory` and `--to-data-tx-directory` to the mounted `/data` volume 
 - use `neo4j-admin restore`'s `--move` parameter in restore-from-backup initContainer to reduce disk usage
 - use the neo4j docker image as the base for restore-from-backup initContainer to reduce the number of container image layers needed by a running pod
 - allow use of workload identity in GCP for restore & backup https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
