### PR TITLE
Restore improvements

### DIFF
--- a/doc/docs/modules/ROOT/pages/backup.adoc
+++ b/doc/docs/modules/ROOT/pages/backup.adoc
@@ -51,6 +51,23 @@ In Neo4j 4.0, the system can be multidatabase; most systems have at least 2 DBs,
 
 ## Steps to Take a Backup
 
+### Use a Service Account to access cloud storage (Google Cloud only)
+
+**GCP**
+
+> Workload Identity is the recommended way to access Google Cloud services from applications running within GKE due to its improved security properties and manageability.
+
+Follow the https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[GCP instructions] to:
+
+- Enable Workload Identity on your GKE cluster
+- Create a Google Cloud IAMServiceAccount that has read and write permissions for your backup location
+- Bind the IAMServiceAccount to the Neo4j deployment's Kubernetes ServiceAccount*
+
+[*] you can configure the name of the Kubernetes ServiceAccount that a Neo4j deployment uses by setting `serviceAccountName` in values.yaml. To check the name of the Kubernetes ServiceAccount that a Neo4j deployment is using run `kubectl get pods -o=jsonpath='{.spec.serviceAccountName}{"\n"}' <your neo4j pod name>`
+
+If you are unable to use Workload Identity with GKE then you can create a service key secret instead as described in the next section.
+
+
 ### Create a service key secret to access cloud storage
 
 First you want to create a kubernetes secret that contains the content of your account service key.  This key must have permissions to access the bucket and backup set that you're trying to restore. 
@@ -92,6 +109,8 @@ kubectl create secret generic neo4j-aws-credentials \
 ```
 
 #### GCP
+
+You do NOT need to follow the steps in this section if you are using Workload Identity for GCP.
 
 Download a JSON formatted service key from Google Cloud that looks like this:
 
@@ -140,7 +159,19 @@ helm install my-neo4j-backup . \
     --set jobSchedule="0 */12 * * *"
 ```
 
-**GCP**
+**GCP with Workload Identity**
+```shell
+helm install my-neo4j-backup . \
+    --set neo4jaddr=my-neo4j.default.svc.cluster.local:6362 \
+    --set bucket=gs://my-bucket \
+    --set database="neo4j\,system" \
+    --set cloudProvider=gcp \
+    --set secretName=NULL \
+    --set serviceAccountName=my-neo4j-backup-sa \
+    --set jobSchedule="0 */12 * * *"
+```
+
+**GCP with service key secret**
 ```shell
 helm install my-neo4j-backup . \
     --set neo4jaddr=my-neo4j.default.svc.cluster.local:6362 \
@@ -193,8 +224,11 @@ discovery address.
 * `databases` a comma separated list of databases to back up.  The default is
 `neo4j,system`.  If your DBMS has many individual databases, you should change this.
 * `cloudProvider` Which cloud service do you want to keep backups on?(gcp or aws)
-* `secretName` the name of the secret you created (neo4j-gcp-credentials|neo4j-aws-credentials)
 * `jobSchedule` what intervals do you want to take backup? It should be cron like "0 */12 * * *". You can set your own schedule(https://crontab.guru/#0_*/12_*_*_*)
+
+At least one of `secretName` and `serviceAccountName` must be set.
+* `secretName` the name of the secret you created (set NULL if using Workload Identity on GKE)
+* `serviceAccountName` the name of the Kubernetes ServiceAccount to use for the backup Job (required if using Workload Identity on GKE)
 
 **Optional environment variables**
 

--- a/doc/docs/modules/ROOT/pages/restore.adoc
+++ b/doc/docs/modules/ROOT/pages/restore.adoc
@@ -25,6 +25,23 @@ the `backup` container in this same code repository.  We recommend you use that 
 inspect the `restore.sh` script, because it needs to make certain assumptions about
 directory structure that come out of archived backups in order to restore properly.
 
+In order to read the backup files from cloud storage the container needs to provide some credentials or authentication. The mechanisms available depends on the cloud service provider.
+
+### Use Service Account to access cloud storage (Google Cloud only)
+
+**GCP**
+
+> Workload Identity is the recommended way to access Google Cloud services from applications running within GKE due to its improved security properties and manageability.
+
+Follow the https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity[GCP instructions] to:
+
+ - Enable Workload Identity on your GKE cluster
+ - Create a Google Cloud IAMServiceAccount that has read permissions for your backup location
+ - Bind the IAMServiceAccount to the Neo4j deployment's Kubernetes ServiceAccount*
+
+[*] you can configure the name of the Kubernetes ServiceAccount that a Neo4j deployment uses by setting `serviceAccountName` in values.yaml. To check the name of the Kubernetes ServiceAccount that a Neo4j deployment is using run `kubectl get pods -o=jsonpath='{.spec.serviceAccountName}{"\n"}' <your neo4j pod name>`
+
+If you are unable to use Workload Identity with GKE then you can create a service key secret instead as described in the next section.
 
 ### Create a service key secret to access cloud storage
 
@@ -47,6 +64,8 @@ kubectl create secret generic neo4j-aws-credentials \
 ```
 
 **GCP**
+
+You do NOT need to follow the steps in this section if you are using Workload Identity for GCP.
 
 - You must create the credential file and this file should look like this:
 ```gcp-credentials.json
@@ -108,7 +127,7 @@ core:
   ...
   restore:
     enabled: true
-    secretName: (neo4j-gcp-credentials|neo4j-aws-credentials|neo4j-azure-credentials) #required
+    secretName: (neo4j-gcp-credentials|neo4j-aws-credentials|neo4j-azure-credentials|NULL) #required. Set NULL if using Workload Identity in GKE.
     database: neo4j,system #required
     cloudProvider: (gcp|aws|azure) #required
     bucket: (gs|s3)://test-neo4j #required
@@ -119,7 +138,7 @@ readReplica:
   ...
   restore:
     enabled: true
-    secretName: (neo4j-gcp-credentials|neo4j-aws-credentials|neo4j-azure-credentials) #required
+    secretName: (neo4j-gcp-credentials|neo4j-aws-credentials|neo4j-azure-credentials|NULL) #required. Set NULL if using Workload Identity in GKE.
     database: neo4j,system #required
     cloudProvider: (gcp|aws|azure) #required
     bucket: (gs|s3)://test-neo4j #required
@@ -134,8 +153,7 @@ readReplica:
 helm install \
     neo4j neo4j/neo4j \
     -f values.yaml \
-    --set acceptLicenseAgreement=yes \
-    --version 4.1.1-1
+    --set acceptLicenseAgreement=yes
 ```
 
 ## Warnings & Indications

--- a/doc/docs/modules/ROOT/pages/restore.adoc
+++ b/doc/docs/modules/ROOT/pages/restore.adoc
@@ -27,7 +27,7 @@ directory structure that come out of archived backups in order to restore proper
 
 In order to read the backup files from cloud storage the container needs to provide some credentials or authentication. The mechanisms available depends on the cloud service provider.
 
-### Use Service Account to access cloud storage (Google Cloud only)
+### Use a Service Account to access cloud storage (Google Cloud only)
 
 **GCP**
 

--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -41,6 +41,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ default $saName .Values.serviceAccount.name }}
+      automountServiceAccountToken: true
       # High value permits checkpointing on Neo4j shutdown.  See: https://neo4j.com/developer/kb/checkpointing-and-log-pruning-interactions/
       terminationGracePeriodSeconds: {{ .Values.core.terminationGracePeriodSeconds }}
       containers:

--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -154,9 +154,11 @@ spec:
             {{- if .Values.core.persistentVolume.subPath }}
             subPath: {{ .Values.core.persistentVolume.subPath }}
             {{- end }}
+          {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
           - name: credentials
             mountPath: /credentials
             readOnly: true
+          {{- end }}
         env:
           - name: DATABASE
             value: {{ .Values.core.restore.database }}
@@ -180,14 +182,14 @@ spec:
         - name: init-script
           configMap:
             name: "{{ .Release.Name }}-init-script"
-        {{ if .Values.core.restore.enabled }}
+        {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
         - name: credentials
           secret:
             secretName: {{ .Values.core.restore.secretName }}
             items:
               - key: credentials
                 path: credentials
-        {{ end }}
+        {{- end }}
         {{- if not .Values.core.persistentVolume.enabled }}
         - name: datadir
           emptyDir: {}

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -41,6 +41,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ default $saName .Values.serviceAccount.name }}
+      automountServiceAccountToken: true
       # High value permits checkpointing on Neo4j shutdown.  See: https://neo4j.com/developer/kb/checkpointing-and-log-pruning-interactions/
       terminationGracePeriodSeconds: {{ .Values.readReplica.terminationGracePeriodSeconds }}
       containers:

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -146,9 +146,11 @@ spec:
             {{- if .Values.core.persistentVolume.subPath }}
             subPath: {{ .Values.core.persistentVolume.subPath }}
             {{- end }}
+          {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
           - name: credentials
             mountPath: /credentials
             readOnly: true
+          {{- end }}
         env:
           - name: DATABASE
             value: {{ .Values.readReplica.restore.database }}
@@ -184,14 +186,14 @@ spec:
         - name: init-script
           configMap:
             name: "{{ .Release.Name }}-init-script"
-        {{ if .Values.readReplica.restore.enabled }}
+        {{- if and .Values.core.restore.enabled .Values.core.restore.secretName }}
         - name: credentials
           secret:
             secretName: {{ .Values.readReplica.restore.secretName }}
             items:
               - key: credentials
                 path: credentials
-        {{ end }}
+        {{- end }}
         {{- if not .Values.readReplica.persistentVolume.enabled }}
         - name: datadir
           emptyDir: {}

--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -180,12 +180,16 @@ function backup_database() {
 }
 
 function activate_gcp() {
-  echo "Activating google credentials before beginning"
-  gcloud auth activate-service-account --key-file "/credentials/credentials"
-
-  if [ $? -ne 0 ]; then
-    echo "Credentials failed; no way to copy to google."
-    exit 1
+  local credentials="/credentials/credentials"
+  if [[ -f "${credentials}" ]]; then
+    echo "Activating google credentials before beginning"
+    gcloud auth activate-service-account --key-file "${credentials}"
+    if [ $? -ne 0 ]; then
+      echo "Credentials failed; no way to copy to google."
+      exit 1
+    fi
+  else
+    echo "No credentials file found. Assuming workload identity is configured"
   fi
 }
 

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -26,6 +26,9 @@ spec:
             {{ $key }}: "{{ $value }}"
             {{- end }}
         spec:
+          {{- if .Values.serviceAccountName }}
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- end }}
           restartPolicy: Never
           shareProcessNamespace: {{ .Values.shareProcessNamespace }}
           containers:
@@ -57,13 +60,16 @@ spec:
                   value: "{{ .Values.checkLabelScanStore }}"
                 - name: CHECK_PROPERTY_OWNERS
                   value: "{{ .Values.checkPropertyOwners }}"
+              {{- if .Values.secretName }}
               volumeMounts:
                 - name: credentials
                   mountPath: /credentials
                   readOnly: true
+              {{- end }}
 {{- if .Values.sidecarContainers }}
 {{ toYaml .Values.sidecarContainers | indent 12 }}
 {{- end }}
+{{- if .Values.secretName }}
           volumes:
             - name: credentials
               secret:
@@ -71,3 +77,4 @@ spec:
                 items:
                   - key: credentials
                     path: credentials
+{{- end }}

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -28,6 +28,8 @@ spec:
         spec:
           {{- if .Values.serviceAccountName }}
           serviceAccountName: {{ .Values.serviceAccountName }}
+          {{- /* explicitly mount token because some service accounts disable automount-by-default and require explicit opt-in */}}
+          automountServiceAccountToken: true
           {{- end }}
           restartPolicy: Never
           shareProcessNamespace: {{ .Values.shareProcessNamespace }}

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -9,6 +9,7 @@ bucket: gs://test-neo4j
 database: neo4j,system
 # cloudProvider can be either gcp, aws, or azure
 cloudProvider: gcp
+# set secretName to NULL if using workload-identity in gcp
 secretName: "neo4j-gcp-credentials"
 pageCache: 2G
 heapSize: 2G
@@ -19,6 +20,9 @@ checkGraph: "true"
 checkLabelScanStore: "true"
 checkPropertyOwners: "false"
 jobSchedule: "0 */12 * * *"
+
+# Set to name of an existing Service Account to use if desired
+serviceAccountName: ""
 
 # When running in mesh
 shareProcessNamespace: false # Needs to be true for the below example configuration to work

--- a/tools/restore/Dockerfile
+++ b/tools/restore/Dockerfile
@@ -1,24 +1,20 @@
-FROM launcher.gcr.io/google/debian9
-RUN apt-get update
-RUN apt-get install -y bash curl wget gnupg apt-transport-https apt-utils lsb-release
-RUN wget -O - https://debian.neo4j.com/neotechnology.gpg.key | apt-key add -
-RUN echo 'deb https://debian.neo4j.com stable 4.2' | tee -a /etc/apt/sources.list.d/neo4j.list
+FROM neo4j:4.2.2-enterprise
+RUN apt-get update \
+ && apt-get install -y curl wget gnupg apt-transport-https apt-utils lsb-release unzip less \
+ && rm -rf /var/lib/apt/lists/*
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN echo "deb http://httpredir.debian.org/debian stretch-backports main" | tee -a /etc/apt/sources.list.d/stretch-backports.list
 
-RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selections
-RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
-
-RUN apt-get update && apt-get install -y neo4j-enterprise=1:4.2.2
-RUN apt-get install -y google-cloud-sdk unzip less
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip awscliv2.zip
-RUN ./aws/install
+RUN apt-get update && apt-get install -y google-cloud-sdk && rm -rf /var/lib/apt/lists/*
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+ && unzip awscliv2.zip && rm awscliv2.zip \
+ && ./aws/install
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-RUN mkdir /data
+RUN mkdir -p /data
 ADD restore/restore.sh /scripts/restore.sh
 RUN chmod +x /scripts/restore.sh
 
+ENTRYPOINT ["bash"]
 CMD ["/scripts/restore.sh"]


### PR DESCRIPTION
Putting this PR on the main fork so that GitHub Actions can run CI on it.

 - the restore initContainer image is now based on the neo4j container image making it likely that nodes won't need to pull a separate image.
 - the restore script now uses the `--move` parameter so that the store files being restored are not duplicated on disk