### PR TITLE
use an explicit volume for staging files before they are uploaded to cloud in backup job

### DIFF
--- a/doc/docs/modules/ROOT/pages/backup.adoc
+++ b/doc/docs/modules/ROOT/pages/backup.adoc
@@ -30,6 +30,12 @@ customize you should bear these requirements in mind:
 The default for Neo4j is to listen only on 127.0.0.1, which will not
 work as other containers would not be able to access the backup port.
 
+### Backup Storage
+
+Backups are stored in a temporary local volume before they are uploaded to cloud. By default an ephemeral Kubernetes `emptyDir` Volume is used.
+
+If the database being backed up is large there might not be sufficient space in local storage. To use alternative storage set `tempVolume` in values.yaml to a different https://kubernetes.io/docs/concepts/storage/volumes[Kubernetes Volume] object.
+
 ### Backup Pointers
 
 All backups will turn into .tar.gz files with date strings when they were taken, such as: `neo4j-2020-06-16-12:32:57.tar.gz`.  They are named after the database

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -62,23 +62,21 @@ spec:
                   value: "{{ .Values.checkLabelScanStore }}"
                 - name: CHECK_PROPERTY_OWNERS
                   value: "{{ .Values.checkPropertyOwners }}"
-              volumeMounts: {{- if and ( not .Values.secretName ) ( not .Values.volume ) }}[]{{- end }}
+              volumeMounts:
                 {{- if .Values.secretName }}
                 - name: credentials
                   mountPath: /credentials
                   readOnly: true
                 {{- end }}
-                {{- if .Values.volume }}
                 - name: "backup"
                   mountPath: "/backups"
-                  {{- if .Values.volumeMount.subPath }}
-                  subPath: "{{ .Values.volumeMount.subPath }}"
-                  {{- end }}
-                {{- end }}
+                  {{- if .Values.tempVolumeMount }}{{- if .Values.tempVolumeMount.subPath }}
+                  subPath: "{{ .Values.tempVolumeMount.subPath }}"
+                  {{- end }}{{- end }}
 {{- if .Values.sidecarContainers }}
 {{ toYaml .Values.sidecarContainers | indent 12 }}
 {{- end }}
-          volumes: {{- if and ( not .Values.secretName ) ( not .Values.volume ) }}[]{{- end }}
+          volumes:
             {{- if .Values.secretName }}
             - name: credentials
               secret:
@@ -87,7 +85,5 @@ spec:
                   - key: credentials
                     path: credentials
             {{- end }}
-            {{- if .Values.volume }}
             - name: "backup"
-              {{ toYaml .Values.volume }}
-            {{- end }}
+              {{ toYaml .Values.tempVolume }}

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -62,21 +62,32 @@ spec:
                   value: "{{ .Values.checkLabelScanStore }}"
                 - name: CHECK_PROPERTY_OWNERS
                   value: "{{ .Values.checkPropertyOwners }}"
-              {{- if .Values.secretName }}
-              volumeMounts:
+              volumeMounts: {{- if and ( not .Values.secretName ) ( not .Values.volume ) }}[]{{- end }}
+                {{- if .Values.secretName }}
                 - name: credentials
                   mountPath: /credentials
                   readOnly: true
-              {{- end }}
+                {{- end }}
+                {{- if .Values.volume }}
+                - name: "backup"
+                  mountPath: "/backups"
+                  {{- if .Values.volumeMount.subPath }}
+                  subPath: "{{ .Values.volumeMount.subPath }}"
+                  {{- end }}
+                {{- end }}
 {{- if .Values.sidecarContainers }}
 {{ toYaml .Values.sidecarContainers | indent 12 }}
 {{- end }}
-{{- if .Values.secretName }}
-          volumes:
+          volumes: {{- if and ( not .Values.secretName ) ( not .Values.volume ) }}[]{{- end }}
+            {{- if .Values.secretName }}
             - name: credentials
               secret:
-                secretName: {{ .Values.secretName }}
+                secretName: "{{ .Values.secretName }}"
                 items:
                   - key: credentials
                     path: credentials
-{{- end }}
+            {{- end }}
+            {{- if .Values.volume }}
+            - name: "backup"
+              {{ toYaml .Values.volume }}
+            {{- end }}

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -24,6 +24,14 @@ jobSchedule: "0 */12 * * *"
 # Set to name of an existing Service Account to use if desired
 serviceAccountName: ""
 
+# volume used as temporary storage for files before they are uploaded to cloud. In the case of a large store nodes may not have sufficient space to stage
+# the backup files on local storage. In that case set an ephemeral or persistent volume with sufficient space here
+tempVolume:
+  emptyDir: {}
+tempVolumeMount:
+  # Subdirectory of temporary volume to mount. useful if volume is not empty
+  # subPath: backups/
+
 # When running in mesh
 shareProcessNamespace: false # Needs to be true for the below example configuration to work
 sidecarContainers: []

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -24,8 +24,7 @@ jobSchedule: "0 */12 * * *"
 # Set to name of an existing Service Account to use if desired
 serviceAccountName: ""
 
-# volume used as temporary storage for files before they are uploaded to cloud. In the case of a large store nodes may not have sufficient space to stage
-# the backup files on local storage. In that case set an ephemeral or persistent volume with sufficient space here
+# Volume to used as temporary storage for files before they are uploaded to cloud. For large databases local storage may not have sufficient space. In that case set an ephemeral or persistent volume with sufficient space here
 tempVolume:
   emptyDir: {}
 tempVolumeMount:


### PR DESCRIPTION
This helps to solve problems where the backup job fails because the node it is running on runs out of space raised in issue: https://github.com/neo4j-contrib/neo4j-helm/issues/173