### PR TITLE
Release Version 4.2.5-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ jobs:
 
               echo "MATCH (n) RETURN count(n) as n;" | kubectl run -i --rm cypher-shell \
                 --namespace $NAMESPACE \
-                --image=neo4j:4.2.2-enterprise --restart=Never \
+                --image=neo4j:4.2.5-enterprise --restart=Never \
                 --command -- ./bin/cypher-shell -u neo4j -p "$NEO4J_PASSWORD" \
                 -a neo4j://$NAME_RESTORE-neo4j.$NAMESPACE.svc.cluster.local 2>&1 | tee restore-result.log
               cp restore-result.log $BUILD_ARTIFACTS/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 4.2.2-1
-appVersion: 4.2.2
+version: 4.2.5-1
+appVersion: 4.2.5
 description: Neo4j is the world's leading graph database
 keywords:
   - graph

--- a/deployment-scenarios/cluster-restore.yaml
+++ b/deployment-scenarios/cluster-restore.yaml
@@ -7,7 +7,7 @@ core:
   restore:
     enabled: true
     image: gcr.io/neo4j-helm/restore
-    imageTag: 4.2.2-1
+    imageTag: 4.2.5-1
     secretName: neo4j-gcp-credentials #neo4j-aws-credentials
     database: neo4j,system
     cloudProvider: gcp #aws
@@ -20,7 +20,7 @@ readReplica:
   restore:
     enabled: true
     image: gcr.io/neo4j-helm/restore
-    imageTag: 4.2.2-1
+    imageTag: 4.2.5-1
     secretName: neo4j-gcp-credentials #neo4j-aws-credentials
     database: neo4j,system
     cloudProvider: gcp #aws

--- a/index.yaml
+++ b/index.yaml
@@ -1,7 +1,17 @@
 apiVersion: v1
-generated: 2020-06-18T00:00:00.499814565-06:00
+generated: 2021-04-29T21:17:54.857071000+02:00
 entries:
   neo4j-backup:
+    - created: 2021-04-29T21:17:54.857071000+02:00
+      description: Neo4j 4.2.5
+      digest: 3d131b91367caa95a05534194c6e757ee677d0fc157b7eef207e35a0fee3bc87
+      home: https://github.com/neo4j-contrib/neo4j-helm
+      name: neo4j
+      sources:
+        - https://github.com/neo4j-contrib/neo4j-helm
+      urls:
+        - https://github.com/neo4j-contrib/neo4j-helm/releases/download/4.2.5-1/neo4j-backup-4.2.5-1.tgz
+      version: 4.2.5-1
     - created: 2021-01-20T00:09:00.499814565-06:00
       description: Neo4j 4.2.2
       digest: af9b1d49ebe6353bd5242fec655ea184e7854666b3fd8b76464543fa9edf5f2d
@@ -63,6 +73,16 @@ entries:
       - https://github.com/neo4j-contrib/neo4j-helm/releases/download/4.0.5-1/neo4j-backup-4.0.5-1.tgz
       version: 4.0.4-1
   neo4j:
+    - created: 2021-04-29T21:17:54.857071000+02:00
+      description: Neo4j 4.2.5
+      digest: 30b3f961377bae49d7c057420343c2b1be2a79edadd82580a5a7fac8dc0b71e5
+      home: https://github.com/neo4j-contrib/neo4j-helm
+      name: neo4j
+      sources:
+        - https://github.com/neo4j-contrib/neo4j-helm
+      urls:
+        - https://github.com/neo4j-contrib/neo4j-helm/releases/download/4.2.5-1/neo4j-4.2.5-1.tgz
+      version: 4.2.5-1
     - created: 2021-01-20T00:09:00.499814565-06:00
       description: 4.2.2-1
       digest: 4484d915b96f09f6d558796060f2e271479f4d98e2fb21bb80477f208cfe1226

--- a/tools/backup/Chart.yaml
+++ b/tools/backup/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: neo4j-backup
 home: https://www.neo4j.com
-version: 4.2.2-1
-appVersion: 4.2.2
+version: 4.2.5-1
+appVersion: 4.2.5
 description: Neo4j Backup Utility
 keywords:
   - graph

--- a/tools/backup/Dockerfile
+++ b/tools/backup/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://httpredir.debian.org/debian stretch-backports main" | tee -
 RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selections
 RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
 
-RUN apt-get update && apt-get install -y neo4j-enterprise=1:4.2.2
+RUN apt-get update && apt-get install -y neo4j-enterprise=1:4.2.5
 RUN apt-get install -y google-cloud-sdk unzip less
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -1,5 +1,5 @@
 image: gcr.io/neo4j-helm/backup
-imageTag: 4.2.2-1
+imageTag: 4.2.5-1
 podLabels: {}
 podAnnotations: {}
 neo4jaddr: holder-neo4j.default.svc.cluster.local:6362

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -24,7 +24,7 @@ jobSchedule: "0 */12 * * *"
 # Set to name of an existing Service Account to use if desired
 serviceAccountName: ""
 
-# Volume to used as temporary storage for files before they are uploaded to cloud. For large databases local storage may not have sufficient space. In that case set an ephemeral or persistent volume with sufficient space here
+# Volume to use as temporary storage for files before they are uploaded to cloud. For large databases local storage may not have sufficient space. In that case set an ephemeral or persistent volume with sufficient space here
 tempVolume:
   emptyDir: {}
 tempVolumeMount:

--- a/tools/restore/Dockerfile
+++ b/tools/restore/Dockerfile
@@ -1,4 +1,4 @@
-FROM neo4j:4.2.2-enterprise
+FROM neo4j:4.2.5-enterprise
 RUN apt-get update \
  && apt-get install -y curl wget gnupg apt-transport-https apt-utils lsb-release unzip less \
  && rm -rf /var/lib/apt/lists/*

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@ name: "neo4j"
 
 # Specs for the Neo4j docker image
 image: "neo4j"
-imageTag: "4.2.2-enterprise"
+imageTag: "4.2.5-enterprise"
 imagePullPolicy: "IfNotPresent"
 # imagePullSecret: registry-secret
 acceptLicenseAgreement: "no"
@@ -158,7 +158,7 @@ core:
   restore:
     enabled: false
     image: gcr.io/neo4j-helm/restore
-    imageTag: 4.2.2-1
+    imageTag: 4.2.5-1
     secretName: neo4j-gcp-credentials
     database: neo4j,system
     cloudProvider: gcp


### PR DESCRIPTION
Move to a base of Neo4j Enterprise 4.2.5

Corresponding docker images have been build and tagged as `4.2.5-1` and pushed to GCR