### PR TITLE
Container security context

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -46,6 +46,8 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.core.terminationGracePeriodSeconds }}
       containers:
       - name: {{ template "neo4j.fullname" . }}
+        securityContext:
+          {{ toYaml .Values.containerSecurityContext | indent 10 }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         envFrom:

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -48,6 +48,8 @@ spec:
       - name: neo4j
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        securityContext:
+         {{ toYaml .Values.containerSecurityContext | indent 10 }}
         # Most pod config is factored into a different configMap, which is user overrideable.
         envFrom:
           - configMapRef:

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -49,7 +49,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         securityContext:
-         {{ toYaml .Values.containerSecurityContext | indent 10 }}
+          {{ toYaml .Values.containerSecurityContext | indent 10 }}
         # Most pod config is factored into a different configMap, which is user overrideable.
         envFrom:
           - configMapRef:

--- a/values.yaml
+++ b/values.yaml
@@ -330,3 +330,6 @@ securityContext: {}
 # volume and filesystem settings local to you
 #  runAsNonRoot: true
 #  runAsUser: 7474
+containerSecurityContext: {}
+# Sets securityContext at the container level. As Pod level securityContext options are limited.
+#   allowPrivilegeEscalation: false

--- a/values.yaml
+++ b/values.yaml
@@ -331,5 +331,5 @@ securityContext: {}
 #  runAsNonRoot: true
 #  runAsUser: 7474
 containerSecurityContext: {}
-# Sets securityContext at the container level. As Pod level securityContext options are limited.
+# Sets securityContext at the container level. As certian security options can only be set at this level.
 #   allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR allows users to set the securityContext at the container level. There are several options like allowPrivilegeEscalation: false that can not be configured at the pod level.

see: [podSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podsecuritycontext-v1-core) vs [SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#securitycontext-v1-core)