### PR TITLE
Backup reports AND version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ jobs:
 
               echo "MATCH (n) RETURN count(n) as n;" | kubectl run -i --rm cypher-shell \
                 --namespace $NAMESPACE \
-                --image=neo4j:4.2.6-enterprise --restart=Never \
+                --image=neo4j:4.2.7-enterprise --restart=Never \
                 --command -- ./bin/cypher-shell -u neo4j -p "$NEO4J_PASSWORD" \
                 -a neo4j://$NAME_RESTORE-neo4j.$NAMESPACE.svc.cluster.local 2>&1 | tee restore-result.log
               cp restore-result.log $BUILD_ARTIFACTS/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
             az storage blob list -c $AZURE_CONTAINER_NAME --account-name helmbackups --prefix build-$CIRCLE_BUILD_NUM/ | tee -a files.txt
             cat files.txt >> $LOGFILE
             total_files=$(cat files.txt | grep name | wc -l)
-            if [ $total_files = 4 ] ; then
+            if [ $total_files = 6 ] ; then
               echo "Test pass" ;
             else
               echo "$total_files total files on Azure storage; failed"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: neo4j
 home: https://www.neo4j.com
-version: 4.2.6-1
-appVersion: 4.2.6
+version: 4.2.7-1
+appVersion: 4.2.7
 description: Neo4j is the world's leading graph database
 keywords:
   - graph

--- a/deployment-scenarios/cluster-restore.yaml
+++ b/deployment-scenarios/cluster-restore.yaml
@@ -7,7 +7,7 @@ core:
   restore:
     enabled: true
     image: gcr.io/neo4j-helm/restore
-    imageTag: 4.2.6-1
+    imageTag: 4.2.7-1
     secretName: neo4j-gcp-credentials #neo4j-aws-credentials
     database: neo4j,system
     cloudProvider: gcp #aws
@@ -20,7 +20,7 @@ readReplica:
   restore:
     enabled: true
     image: gcr.io/neo4j-helm/restore
-    imageTag: 4.2.6-1
+    imageTag: 4.2.7-1
     secretName: neo4j-gcp-credentials #neo4j-aws-credentials
     database: neo4j,system
     cloudProvider: gcp #aws

--- a/index.yaml
+++ b/index.yaml
@@ -13,7 +13,7 @@ entries:
         - https://github.com/neo4j-contrib/neo4j-helm/releases/download/4.2.6-1/neo4j-backup-4.2.6-1.tgz
       version: 4.2.6-1
     - created: 2021-04-29T21:17:54.857071000+02:00
-      description: Neo4j 4.2.5
+      description: Neo4j 4.2.6
       digest: 3d131b91367caa95a05534194c6e757ee677d0fc157b7eef207e35a0fee3bc87
       home: https://github.com/neo4j-contrib/neo4j-helm
       name: neo4j

--- a/index.yaml
+++ b/index.yaml
@@ -13,7 +13,7 @@ entries:
         - https://github.com/neo4j-contrib/neo4j-helm/releases/download/4.2.6-1/neo4j-backup-4.2.6-1.tgz
       version: 4.2.6-1
     - created: 2021-04-29T21:17:54.857071000+02:00
-      description: Neo4j 4.2.6
+      description: Neo4j 4.2.5
       digest: 3d131b91367caa95a05534194c6e757ee677d0fc157b7eef207e35a0fee3bc87
       home: https://github.com/neo4j-contrib/neo4j-helm
       name: neo4j

--- a/tools/backup/Chart.yaml
+++ b/tools/backup/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: neo4j-backup
 home: https://www.neo4j.com
-version: 4.2.6-1
-appVersion: 4.2.6
+version: 4.2.7-1
+appVersion: 4.2.7
 description: Neo4j Backup Utility
 keywords:
   - graph

--- a/tools/backup/Dockerfile
+++ b/tools/backup/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://httpredir.debian.org/debian stretch-backports main" | tee -
 RUN echo "neo4j-enterprise neo4j/question select I ACCEPT" | debconf-set-selections
 RUN echo "neo4j-enterprise neo4j/license note" | debconf-set-selections
 
-RUN apt-get update && apt-get install -y neo4j-enterprise=1:4.2.6
+RUN apt-get update && apt-get install -y neo4j-enterprise=1:4.2.7
 RUN apt-get install -y google-cloud-sdk unzip less
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip

--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -152,7 +152,8 @@ function backup_database() {
     --check-indexes=$CHECK_INDEXES \
     --check-label-scan-store=$CHECK_LABEL_SCAN_STORE \
     --check-property-owners=$CHECK_PROPERTY_OWNERS \
-    --verbose
+    --verbose \
+    | tee "${REPORT_DIR}/backup.log"
 
   # Docs: see exit codes here: https://neo4j.com/docs/operations-manual/current/backup/performing/#backup-performing-command
   backup_result=$?

--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -123,6 +123,11 @@ function cloud_copy() {
 function backup_database() {
   db=$1
 
+  export REPORT_DIR="/backups/.report_$db"
+  mkdir -p "${REPORT_DIR}"
+  echo "Removing any existing files from ${REPORT_DIR}"
+  rm -rfv "${REPORT_DIR}"/*
+
   export BACKUP_SET="$db-$(date "+%Y-%m-%d-%H:%M:%S")"
   export LATEST_POINTER="$db-latest.tar.gz"
 
@@ -142,6 +147,7 @@ function backup_database() {
     --pagecache=$PAGE_CACHE \
     --fallback-to-full=$FALLBACK_TO_FULL \
     --check-consistency=$CHECK_CONSISTENCY \
+    --report-dir="${REPORT_DIR}" \
     --check-graph=$CHECK_GRAPH \
     --check-indexes=$CHECK_INDEXES \
     --check-label-scan-store=$CHECK_LABEL_SCAN_STORE \
@@ -156,6 +162,11 @@ function backup_database() {
   2) echo "Backup succeeded but consistency check failed - $db" ;;
   3) echo "Backup succeeded but consistency check found inconsistencies - $db" ;;
   esac
+
+  echo "Backup report(s):"
+  du -hs "${REPORT_DIR}"
+  ls -l "${REPORT_DIR}"
+  cat "${REPORT_DIR}"/*
 
   if [ $backup_result -eq 1 ]; then
     echo "Aborting other actions; backup failed"
@@ -188,6 +199,29 @@ function backup_database() {
   else
     echo "Removing /backups/$BACKUP_SET.tar.gz"
     rm "/backups/$BACKUP_SET.tar.gz"
+  fi
+
+
+  echo "Archiving and Compressing -> ${REPORT_DIR}/$BACKUP_SET.tar"
+
+  tar -zcvf "backups/$BACKUP_SET.report.tar.gz" "${REPORT_DIR}" --remove-files
+
+  if [ $? -ne 0 ]; then
+    echo "REPORT ARCHIVING OF ${REPORT_DIR} FAILED"
+    exit 1
+  fi
+
+  echo "Zipped report size:"
+  du -hs "/backups/$BACKUP_SET.report.tar.gz"
+
+  cloud_copy "/backups/$BACKUP_SET.report.tar.gz" $db
+
+  if [ $? -ne 0 ]; then
+    echo "Storage copy of report for ${REPORT_DIR} FAILED"
+    exit 1
+  else
+    echo "Removing /backups/$BACKUP_SET.report.tar.gz"
+    rm "/backups/$BACKUP_SET.report.tar.gz"
   fi
 }
 

--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -120,6 +120,30 @@ function cloud_copy() {
   esac
 }
 
+function upload_report() {
+  echo "Archiving and Compressing -> ${REPORT_DIR}/$BACKUP_SET.tar"
+
+  tar -zcvf "backups/$BACKUP_SET.report.tar.gz" "${REPORT_DIR}" --remove-files
+
+  if [ $? -ne 0 ]; then
+    echo "REPORT ARCHIVING OF ${REPORT_DIR} FAILED"
+    exit 1
+  fi
+
+  echo "Zipped report size:"
+  du -hs "/backups/$BACKUP_SET.report.tar.gz"
+
+  cloud_copy "/backups/$BACKUP_SET.report.tar.gz" $db
+
+  if [ $? -ne 0 ]; then
+    echo "Storage copy of report for ${REPORT_DIR} FAILED"
+    exit 1
+  else
+    echo "Removing /backups/$BACKUP_SET.report.tar.gz"
+    rm "/backups/$BACKUP_SET.report.tar.gz"
+  fi
+}
+
 function backup_database() {
   db=$1
 
@@ -167,9 +191,9 @@ function backup_database() {
   echo "Backup report(s):"
   du -hs "${REPORT_DIR}"
   ls -l "${REPORT_DIR}"
-  cat "${REPORT_DIR}"/*
 
   if [ $backup_result -eq 1 ]; then
+    upload_report
     echo "Aborting other actions; backup failed"
     exit 1
   fi
@@ -202,28 +226,7 @@ function backup_database() {
     rm "/backups/$BACKUP_SET.tar.gz"
   fi
 
-
-  echo "Archiving and Compressing -> ${REPORT_DIR}/$BACKUP_SET.tar"
-
-  tar -zcvf "backups/$BACKUP_SET.report.tar.gz" "${REPORT_DIR}" --remove-files
-
-  if [ $? -ne 0 ]; then
-    echo "REPORT ARCHIVING OF ${REPORT_DIR} FAILED"
-    exit 1
-  fi
-
-  echo "Zipped report size:"
-  du -hs "/backups/$BACKUP_SET.report.tar.gz"
-
-  cloud_copy "/backups/$BACKUP_SET.report.tar.gz" $db
-
-  if [ $? -ne 0 ]; then
-    echo "Storage copy of report for ${REPORT_DIR} FAILED"
-    exit 1
-  else
-    echo "Removing /backups/$BACKUP_SET.report.tar.gz"
-    rm "/backups/$BACKUP_SET.report.tar.gz"
-  fi
+  upload_report
 }
 
 function activate_gcp() {

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -1,5 +1,5 @@
 image: gcr.io/neo4j-helm/backup
-imageTag: 4.2.6-1
+imageTag: 4.2.7-1
 podLabels: {}
 podAnnotations: {}
 neo4jaddr: holder-neo4j.default.svc.cluster.local:6362

--- a/tools/restore/Dockerfile
+++ b/tools/restore/Dockerfile
@@ -1,4 +1,4 @@
-FROM neo4j:4.2.6-enterprise
+FROM neo4j:4.2.7-enterprise
 RUN apt-get update \
  && apt-get install -y curl wget gnupg apt-transport-https apt-utils lsb-release unzip less \
  && rm -rf /var/lib/apt/lists/*

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@ name: "neo4j"
 
 # Specs for the Neo4j docker image
 image: "neo4j"
-imageTag: "4.2.6-enterprise"
+imageTag: "4.2.7-enterprise"
 imagePullPolicy: "IfNotPresent"
 # imagePullSecret: registry-secret
 acceptLicenseAgreement: "no"
@@ -159,7 +159,7 @@ core:
   restore:
     enabled: false
     image: gcr.io/neo4j-helm/restore
-    imageTag: 4.2.6-1
+    imageTag: 4.2.7-1
     secretName: neo4j-gcp-credentials
     database: neo4j,system
     cloudProvider: gcp


### PR DESCRIPTION
Bump version to 4.2.7 and fix the consistency check report produced by neo4j admin backup in the artifacts that are uploaded for storage.

n.b. currently it's not really possible to run anything that relies on helm-chart specific docker images through CI without doing a version bump.