### PR TITLE
Update PodAnnotations format

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -34,10 +34,9 @@ spec:
         {{ $key }}: "{{ $value }}"
         {{- end }}
       {{- if .Values.podAnnotations }}
-      annotations:
-        {{-  range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: "{{ $value }}"
-        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ default $saName .Values.serviceAccount.name }}

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -34,10 +34,9 @@ spec:
         {{ $key }}: "{{ $value }}"
         {{- end }}
       {{- if .Values.podAnnotations }}
-      annotations:
-        {{-  range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: "{{ $value }}"
-        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ default $saName .Values.serviceAccount.name }}


### PR DESCRIPTION
Update the Pod Annotations to be passed in as any format instead of parsing through Key Values. See Issue #192 