### PR TITLE
Allow use of IAM Role for Service Account -  IRSA

### DIFF
--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -244,19 +244,18 @@ function activate_gcp() {
 }
 
 function activate_aws() {
-  echo "Activating aws credentials before beginning"
-  mkdir -p /root/.aws/
-  cp /credentials/credentials ~/.aws/config
-
-  if [ $? -ne 0 ]; then
-    echo "Credentials failed; no way to copy to aws."
-    exit 1
-  fi
-
-  aws sts get-caller-identity
-  if [ $? -ne 0 ]; then
-    echo "Credentials failed; no way to copy to aws."
-    exit 1
+  local credentials="/credentials/credentials"
+  if [[ -f "${credentials}" ]]; then
+    echo "Activating aws credentials before beginning"
+    mkdir -p /root/.aws/
+    cp /credentials/credentials ~/.aws/config
+    aws sts get-caller-identity
+    if [ $? -ne 0 ]; then
+      echo "Credentials failed; no way to copy to aws."
+      exit 1
+    fi
+  else
+    echo "No credentials file found. Assuming IAM Role for Service Account - IRSA is configured"
   fi
 }
 

--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -249,6 +249,10 @@ function activate_aws() {
     echo "Activating aws credentials before beginning"
     mkdir -p /root/.aws/
     cp /credentials/credentials ~/.aws/config
+    if [ $? -ne 0 ]; then
+      echo "Credentials failed; no way to copy to aws."
+      exit 1
+    fi
     aws sts get-caller-identity
     if [ $? -ne 0 ]; then
       echo "Credentials failed; no way to copy to aws."

--- a/tools/restore/restore.sh
+++ b/tools/restore/restore.sh
@@ -268,6 +268,10 @@ function activate_aws() {
     echo "Activating aws credentials before beginning"
     mkdir -p /root/.aws/
     cp /credentials/credentials ~/.aws/config
+    if [ $? -ne 0 ]; then
+      echo "Credentials failed; no way to copy to aws."
+      exit 1
+    fi
     aws sts get-caller-identity
     if [ $? -ne 0 ]; then
       echo "Credentials failed; no way to copy to aws."

--- a/tools/restore/restore.sh
+++ b/tools/restore/restore.sh
@@ -263,19 +263,18 @@ function activate_gcp() {
 }
 
 function activate_aws() {
-  echo "Activating aws credentials before beginning"
-  mkdir -p /root/.aws/
-  cp /credentials/credentials ~/.aws/config
-
-  if [ $? -ne 0 ]; then
-    echo "Credentials failed; no way to copy to aws."
-    exit 1
-  fi
-
-  aws sts get-caller-identity
-  if [ $? -ne 0 ]; then
-    echo "Credentials failed; no way to copy to aws."
-    exit 1
+  local credentials="/credentials/credentials"
+  if [[ -f "${credentials}" ]]; then
+    echo "Activating aws credentials before beginning"
+    mkdir -p /root/.aws/
+    cp /credentials/credentials ~/.aws/config
+    aws sts get-caller-identity
+    if [ $? -ne 0 ]; then
+      echo "Credentials failed; no way to copy to aws."
+      exit 1
+    fi
+  else
+    echo "No credentials file found. Assuming IAM Role for Service Account - IRSA is configured"
   fi
 }
 


### PR DESCRIPTION
To prevent use of IAM Access keys, a best practice is to use IRSA. With the current scripts, it wasn't possible. This PR aims to fix it. 