### PR TITLE
setting cluster size at runtime to 2 is considered an anti-pattern

### DIFF
--- a/templates/common-configmap.yaml
+++ b/templates/common-configmap.yaml
@@ -20,7 +20,7 @@ data:
   NEO4J_dbms_connector_http_listen__address: 0.0.0.0:7474
   NEO4J_dbms_connector_https_listen__address: 0.0.0.0:7473
   NEO4J_causal__clustering_minimum__core__cluster__size__at__formation: "3"
-  NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: "2"
+  NEO4J_causal__clustering_minimum__core__cluster__size__at__runtime: "3"
   NEO4J_dbms_jvm_additional: "-XX:+ExitOnOutOfMemoryError"
   NEO4J_metrics_graphite_enabled: "{{ .Values.metrics.graphite.enabled }}"
   NEO4J_metrics_graphite_server: "{{ .Values.metrics.graphite.server }}"


### PR DESCRIPTION
see https://neo4j.com/developer/kb/a-demonstration-of-cluster-size-at-formation-and-runtime/