### PR TITLE
fix indent on tempVolume and allow use as subchart

### DIFF
--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -86,4 +86,8 @@ spec:
                     path: credentials
             {{- end }}
             - name: "backup"
-              {{ toYaml .Values.tempVolume }}
+{{- if .Values.tempVolume }}
+{{ toYaml .Values.tempVolume | indent 14 }}
+{{- else }}
+              emptyDir: {}
+{{- end }}

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -86,8 +86,6 @@ spec:
                     path: credentials
             {{- end }}
             - name: "backup"
-{{- if .Values.tempVolume }}
-{{ toYaml .Values.tempVolume | indent 14 }}
-{{- else }}
-              emptyDir: {}
+{{- with .Values.tempVolume.emptyDir }}
+{{- toYaml . | nindent 14 }}
 {{- end }}

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -26,8 +26,8 @@ serviceAccountName: ""
 
 # Volume to use as temporary storage for files before they are uploaded to cloud. For large databases local storage may not have sufficient space. In that case set an ephemeral or persistent volume with sufficient space here
 # The chart defaults to an emptyDir, use this to overwrite default behavior
-# tempVolume:
-#   emptyDir: {}
+tempVolume:
+  emptyDir: {}
 
 tempVolumeMount:
   # Subdirectory of temporary volume to mount. useful if volume is not empty

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -25,8 +25,10 @@ jobSchedule: "0 */12 * * *"
 serviceAccountName: ""
 
 # Volume to use as temporary storage for files before they are uploaded to cloud. For large databases local storage may not have sufficient space. In that case set an ephemeral or persistent volume with sufficient space here
-tempVolume:
-  emptyDir: {}
+# The chart defaults to an emptyDir, use this to overwrite default behavior
+# tempVolume:
+#   emptyDir: {}
+
 tempVolumeMount:
   # Subdirectory of temporary volume to mount. useful if volume is not empty
   # subPath: backups/


### PR DESCRIPTION
Using this backup chart with a custom tempVolume is not possible when part of a subchart as it emptyDir cannot be set to null see https://github.com/helm/helm/issues/9136
This PR allows that without breaking changes

Goal here is to use a named PVC to do incremental backups, would it be interesting to add directly to this chart ?