### PR TITLE
Set default SecretName to null so it can be used as subchart without …

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -160,7 +160,7 @@ core:
     enabled: false
     image: gcr.io/neo4j-helm/restore
     imageTag: 4.2.7-2
-    secretName: neo4j-gcp-credentials
+    secretName: null
     database: neo4j,system
     cloudProvider: gcp
     bucket: gs://test-neo4j
@@ -249,7 +249,7 @@ readReplica:
     enabled: false
     image: gcr.io/neo4j-helm/restore
     imageTag: 4.1.0-1
-    secretName: neo4j-gcp-credentials
+    secretName: null
     database: neo4j,system
     cloudProvider: gcp
     bucket: gs://test-neo4j


### PR DESCRIPTION
Hi @eastlondoner ,

I run into the same issue as https://github.com/neo4j-contrib/neo4j-helm/pull/199 when trying to use the main chart without secrets storing credentials.
The proposed solution is simply to set the value to `null`.
Looking at `deployment-scenarios` it should be OK as they all set there own value for that key. I assume it will be the same for other users of this chart.