### PR TITLE
allow to keep backup files for incremental backups using PVC

### DIFF
--- a/tools/backup/Chart.yaml
+++ b/tools/backup/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: neo4j-backup
 home: https://www.neo4j.com
-version: 4.2.7-2
+version: 4.2.7-3
 appVersion: 4.2.7
 description: Neo4j Backup Utility
 keywords:

--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -57,6 +57,10 @@ if [ -z $REMOVE_EXISTING_FILES ]; then
   export REMOVE_EXISTING_FILES="true"
 fi
 
+if [ -z $REMOVE_BACKUP_FILES ]; then
+  export REMOVE_BACKUP_FILES="true"
+fi
+
 function clean_backups_directory() {
   echo "Removing any existing files from /backups"
   rm -rfv /backups/*
@@ -213,8 +217,12 @@ function backup_database() {
   ls -l "/backups/$db"
 
   echo "Archiving and Compressing -> /backups/$BACKUP_SET.tar"
-
-  tar -zcvf "/backups/$BACKUP_SET.tar.gz" "/backups/$db" --remove-files
+  
+  if [ "${REMOVE_BACKUP_FILES}" == "true" ]; then
+    tar -zcvf "/backups/$BACKUP_SET.tar.gz" "/backups/$db" --remove-files
+  else
+    tar -zcvf "/backups/$BACKUP_SET.tar.gz" "/backups/$db"
+  fi
 
   if [ $? -ne 0 ]; then
     echo "BACKUP ARCHIVING OF $db FAILED"

--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -62,6 +62,10 @@ spec:
                   value: "{{ .Values.checkLabelScanStore }}"
                 - name: CHECK_PROPERTY_OWNERS
                   value: "{{ .Values.checkPropertyOwners }}"
+                - name: REMOVE_EXISTING_FILES
+                  value: "{{ .Values.removeExistingFiles }}"
+                - name: REMOVE_BACKUP_FILES
+                  value: "{{ .Values.removeBackupFiles }}"
               volumeMounts:
                 {{- if .Values.secretName }}
                 - name: credentials

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -1,5 +1,5 @@
 image: gcr.io/neo4j-helm/backup
-imageTag: 4.2.7-2
+imageTag: 4.2.7-3
 podLabels: {}
 podAnnotations: {}
 neo4jaddr: holder-neo4j.default.svc.cluster.local:6362
@@ -19,6 +19,8 @@ checkIndexes: "true"
 checkGraph: "true"
 checkLabelScanStore: "true"
 checkPropertyOwners: "false"
+removeExistingFiles: "true"
+removeBackupFiles: "true"
 jobSchedule: "0 */12 * * *"
 
 # Set to name of an existing Service Account to use if desired


### PR DESCRIPTION
Changing a bit the code of backup.sh to allow us to keep backups files on PVC so we can only do an incremental after that.
End goal is to reduce backup time and inpact on our core cluster as we don't have readreplicas (3 nodes license)