### PR TITLE
Improve probe overrides

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -133,11 +133,23 @@ spec:
 {{ toYaml .Values.core.additionalVolumeMounts | indent 8}}
         {{- end }}
         startupProbe:
+{{- if .Values.startupProbeOverride }}
+{{ toYaml .Values.startupProbeOverride | indent 10 }}
+{{- else }}
 {{ toYaml .Values.startupProbe | indent 10 }}
+{{- end }}
         readinessProbe:
+{{- if .Values.readinessProbeOverride }}
+{{ toYaml .Values.readinessProbeOverride | indent 10 }}
+{{- else }}
 {{ toYaml .Values.readinessProbe | indent 10 }}
+{{- end }}
         livenessProbe:
+{{- if .Values.livenessProbeOverride }}
+{{ toYaml .Values.livenessProbeOverride | indent 10 }}
+{{- else }}
 {{ toYaml .Values.livenessProbe | indent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
 {{- if .Values.core.sidecarContainers }}

--- a/templates/readreplicas-statefulset.yaml
+++ b/templates/readreplicas-statefulset.yaml
@@ -129,11 +129,23 @@ spec:
 {{ toYaml .Values.readReplica.additionalVolumeMounts | indent 8}}
         {{- end }}
         startupProbe:
+{{- if .Values.startupProbeOverride }}
+{{ toYaml .Values.startupProbeOverride | indent 10 }}
+{{- else }}
 {{ toYaml .Values.startupProbe | indent 10 }}
+{{- end }}
         readinessProbe:
+{{- if .Values.readinessProbeOverride }}
+{{ toYaml .Values.readinessProbeOverride | indent 10 }}
+{{- else }}
 {{ toYaml .Values.readinessProbe | indent 10 }}
+{{- end }}
         livenessProbe:
+{{- if .Values.livenessProbeOverride }}
+{{ toYaml .Values.livenessProbeOverride | indent 10 }}
+{{- else }}
 {{ toYaml .Values.livenessProbe | indent 10 }}
+{{- end }}
         resources:
 {{ toYaml .Values.readReplica.resources | indent 10 }}
 {{- if .Values.core.sidecarContainers }}

--- a/values.yaml
+++ b/values.yaml
@@ -271,7 +271,17 @@ readinessProbe:
   timeoutSeconds: 2
   periodSeconds: 10
   tcpSocket:
-    port: 7687 
+    port: 7687
+
+# If you wish to use other probes, like httpGet, input your full probe params here
+readinessProbeOverride:
+  # initialDelaySeconds: 120
+  # failureThreshold: 3
+  # timeoutSeconds: 2
+  # periodSeconds: 10
+  # httpGet:
+  #   path: /db/mydatabase/cluster/available
+  #   port: 7474
 
 livenessProbe:
   initialDelaySeconds: 300
@@ -281,6 +291,16 @@ livenessProbe:
   tcpSocket:
     port: 7687
 
+# If you wish to use other probes, like httpGet, input your full livenessProbe params here
+livenessProbeOverride:
+  # initialDelaySeconds: 300
+  # periodSeconds: 10
+  # failureThreshold: 3
+  # timeoutSeconds: 2
+  # httpGet:
+  #   path: /db/mydatabase/cluster/available
+  #   port: 7474
+
 # Startup probes are used to know when a container application has started.
 # If such a probe is configured, it disables liveness and readiness checks until it succeeds
 startupProbe:
@@ -288,6 +308,13 @@ startupProbe:
   periodSeconds: 25
   tcpSocket:
     port: 7687
+
+startupProbeOverride:
+  # failureThreshold: 2000
+  # periodSeconds: 25
+  # httpGet:
+  #   path: /db/mydatabase/cluster/available
+  #   port: 7474
 
 ## (OPTIONAL) Expose Neo4j metrics
 # The structure of this object matches the Neo4j config syntax


### PR DESCRIPTION
### Summary of the problem

#### Values file
```yaml
livenessProbe:
  initialDelaySeconds: 180
  periodSeconds: 10
  failureThreshold: 3
  timeoutSeconds: 2
  httpGet:
    path: /db/mydatabase/cluster/available
    port: 7474
```
#### Final Template generated
```yaml
livenessProbe:
  failureThreshold: 3
  httpGet:
    path: /db/mydatabase/cluster/available
    port: 7474
  initialDelaySeconds: 180
  periodSeconds: 10
  tcpSocket:
    port: 7687
  timeoutSeconds: 2
```

If you realize, tcpSocket is not expected to be in as we are using httpGet check.

It's documented here:
1. https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key
2. https://github.com/helm/helm/issues/9136

Option 1 as documented, will be to set null to the values. but this can be very messy. (If there is a new addon or change, we have to set it as null too)

My suggestion is to have an override values file where we can state any liveness that we wish to override. This is backward compatible and there is no breaking change. 