### PR TITLE
suppress jvm startup message in memrec

### DIFF
--- a/templates/pod-init-script.yaml
+++ b/templates/pod-init-script.yaml
@@ -56,7 +56,7 @@ data:
       # So dbms.memory.heap.max_size=9000m => export NEO4J_dbms_memory_heap_max__size=9000m
 
       echo '' > /var/lib/neo4j/conf/memory-recommendations.sh
-      for line in $( /var/lib/neo4j/bin/neo4j-admin memrec | grep -v '^\#' ) ; do
+      for line in $( /var/lib/neo4j/bin/neo4j-admin memrec | grep -v '^Selecting\ JVM' | grep -v '^\#' ) ; do
           # print out the memory recommendation that is being applied
           echo "${line}"
           echo "export $( echo "${line}" | sed 's/_/__/g' | sed 's/\./_/g' | sed 's/^/NEO4J_/g' )" >> /var/lib/neo4j/conf/memory-recommendations.sh


### PR DESCRIPTION
The first line outputted by the script `/var/lib/neo4j/bin/neo4j-admin memrec` is a startup message from the JVM itself like:
```
Selecting JVM - Version:11.0.12, Name:OpenJDK 64-Bit Server VM, Vendor:Oracle Corporation
```

This interferes with the subsequent `for` loop in the `init-script`, as it will try to set all of these strings as a `NEO4J_` env variable. The init script is still functional, but the error messages are confusing and are polluting the log files:
```
Calling neo4j-admin memrec to suggest memory settings:
Selecting
JVM
-
Version:11.0.12,
Name:OpenJDK
64-Bit
Server
VM,
Vendor:Oracle
Corporation
dbms.memory.heap.initial_size=4600m
dbms.memory.heap.max_size=4600m
dbms.memory.pagecache.size=4g
dbms.jvm.additional=-XX:+ExitOnOutOfMemoryError
/var/lib/neo4j/conf/memory-recommendations.sh: line 4: export: `NEO4J_-': not a valid identifier
/var/lib/neo4j/conf/memory-recommendations.sh: line 5: export: `NEO4J_Version:11_0_12,': not a valid identifier
/var/lib/neo4j/conf/memory-recommendations.sh: line 6: export: `NEO4J_Name:OpenJDK': not a valid identifier
/var/lib/neo4j/conf/memory-recommendations.sh: line 7: export: `NEO4J_64-Bit': not a valid identifier
/var/lib/neo4j/conf/memory-recommendations.sh: line 9: export: `NEO4J_VM,': not a valid identifier
/var/lib/neo4j/conf/memory-recommendations.sh: line 10: export: `NEO4J_Vendor:Oracle': not a valid identifier
``` 

Added an additional `grep` statement to excluded any lines starting with `Selecting JVM`, to overcome this issue.