### PR TITLE
Add backoff limit for cronjob backup

### DIFF
--- a/tools/backup/templates/backup.yaml
+++ b/tools/backup/templates/backup.yaml
@@ -15,6 +15,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: {{ .Values.backoffLimit }}
       template:
         metadata:
         {{- with .Values.podAnnotations }}

--- a/tools/backup/values.yaml
+++ b/tools/backup/values.yaml
@@ -22,6 +22,7 @@ checkPropertyOwners: "false"
 removeExistingFiles: "true"
 removeBackupFiles: "true"
 jobSchedule: "0 */12 * * *"
+backoffLimit: 6
 
 # Set to name of an existing Service Account to use if desired
 serviceAccountName: ""


### PR DESCRIPTION
Currently, backoff limit is not specified but some users would like to not retry the backup if it fails.