### PR TITLE
fix containerSecurityContext intendation

### DIFF
--- a/templates/core-statefulset.yaml
+++ b/templates/core-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
       - name: {{ template "neo4j.fullname" . }}
         securityContext:
-          {{ toYaml .Values.containerSecurityContext | indent 10 }}
+{{ toYaml .Values.containerSecurityContext | indent 10 }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         envFrom:


### PR DESCRIPTION
When setting a containerSecurityContext such as: 
```
containerSecurityContext:
  allowPrivilegeEscalation: false
  fsGroup: 7474
```
the indentation is 10 chars too wide, as a result the chart wont render properly.

```bash
Error: YAML parse error on neo4j/templates/core-statefulset.yaml: error converting YAML to JSON: yaml: line 36: did not find expected key
```