### PR TITLE
Fix broken link to Operations manual

### DIFF
--- a/doc/docs/modules/ROOT/pages/index.adoc
+++ b/doc/docs/modules/ROOT/pages/index.adoc
@@ -11,7 +11,7 @@ For Neo4j standalone, productized Helm charts are available for Neo4j 4.3 and ab
 For Neo4j Causal Cluster, productized Helm charts are available for Neo4j 4.4 and above.
 
 That is the recommended way to run Neo4j in Kubernetes.
-Full details are in the https://neo4j.com/docs/operations-manual/current/kubernetes/:[Kubernetes section of the Neo4j operations manual].
+Full details are in the https://neo4j.com/docs/operations-manual/current/kubernetes/[Kubernetes section of the Neo4j Operations manual].
 
 The neo4j-helm Labs Helm charts described here will keep being updated for 4.4.x, but updates will stop from the next major release 5.0.
 ====


### PR DESCRIPTION
Fixed the link to the Kubernetes section of the Neo4j Operations manual