### PR TITLE
Added Azure blob overwrite flag

### DIFF
--- a/tools/backup/backup.sh
+++ b/tools/backup/backup.sh
@@ -113,7 +113,8 @@ function cloud_copy() {
                        --file "$backup_path" \
                        --name $CONTAINER_FILE \
                        --account-name "$ACCOUNT_NAME" \
-                       --account-key "$ACCOUNT_KEY"
+                       --account-key "$ACCOUNT_KEY" \
+                       --overwrite "true"
 
     if [ "${artifact_type}" = "backup" ]; then
       latest_name=$CONTAINER_PATH/$database/${LATEST_POINTER}


### PR DESCRIPTION
Azure has made a change to their blob library making it so previous blobs are not overwritten by default, adding `--overwrite true` flag to enable it again.